### PR TITLE
Says explicitly that verbose mode enables log output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ pub fn parse_args() -> MiniserveConfig {
             Arg::with_name("verbose")
                 .short("v")
                 .long("verbose")
-                .help("Be verbose"),
+                .help("Be verbose, include emitting access logs"),
         ).arg(
             Arg::with_name("PATH")
                 .required(false)


### PR DESCRIPTION
Fixes #16