### PR TITLE
Fix auth check

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -81,12 +81,20 @@ fn parse_auth(src: &str) -> Result<(String, String), String> {
 
     let username = match split.next() {
         Some(username) => username,
-        None => return Err("Invalid credentials string, expected format is username:password".to_owned())
+        None => {
+            return Err(
+                "Invalid credentials string, expected format is username:password".to_owned(),
+            )
+        }
     };
 
     let password = match split.next() {
         Some(password) => password,
-        None => return Err("Invalid credentials string, expected format is username:password".to_owned())
+        None => {
+            return Err(
+                "Invalid credentials string, expected format is username:password".to_owned(),
+            )
+        }
     };
     // Should we allow empty passwords ?
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -77,13 +77,24 @@ fn parse_interface(src: &str) -> Result<IpAddr, std::net::AddrParseError> {
 
 /// Checks wether the auth string is valid, i.e. it follows the syntax username:password
 fn parse_auth(src: &str) -> Result<(String, String), String> {
-    match src.find(':') {
-        Some(_) => {
-            let split = src.split(':').collect::<Vec<_>>();
-            Ok((split[0].to_owned(), split[1].to_owned()))
-        }
-        None => Err("Correct format is username:password".to_owned()),
+    let mut split = src.splitn(2, ':');
+
+    let username = match split.next() {
+        Some(username) => username,
+        None => return Err("Invalid credentials string, expected format is username:password".to_owned())
+    };
+
+    let password = match split.next() {
+        Some(password) => password,
+        None => return Err("Invalid credentials string, expected format is username:password".to_owned())
+    };
+    // Should we allow empty passwords ?
+
+    if username.len() > 255 {
+        return Err("Username length cannot exceed 255 characters".to_owned());
     }
+
+    Ok((username.to_owned(), password.to_owned()))
 }
 
 /// Parses the command line arguments

--- a/src/args.rs
+++ b/src/args.rs
@@ -98,7 +98,7 @@ fn parse_auth(src: &str) -> Result<(String, String), String> {
         }
     };
 
-    // To make it Windows-compatible,the password needs to be shorter than 255 characters.
+    // To make it Windows-compatible, the password needs to be shorter than 255 characters.
     // After 255 characters, Windows will truncate the value.
     // As for the username, the spec does not mention a limit in length
     if password.len() > 255 {

--- a/src/args.rs
+++ b/src/args.rs
@@ -89,6 +89,7 @@ fn parse_auth(src: &str) -> Result<(String, String), String> {
     };
 
     let password = match split.next() {
+        // This allows empty passwords, as the spec does not forbid it
         Some(password) => password,
         None => {
             return Err(
@@ -96,10 +97,12 @@ fn parse_auth(src: &str) -> Result<(String, String), String> {
             )
         }
     };
-    // Should we allow empty passwords ?
 
-    if username.len() > 255 {
-        return Err("Username length cannot exceed 255 characters".to_owned());
+    // To make it Windows-compatible,the password needs to be shorter than 255 characters.
+    // After 255 characters, Windows will truncate the value.
+    // As for the username, the spec does not mention a limit in length
+    if password.len() > 255 {
+        return Err("Password length cannot exceed 255 characters".to_owned());
     }
 
     Ok((username.to_owned(), password.to_owned()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,14 +134,14 @@ fn main() {
                 ))
                 .bold()
         ));
-        let random_route = miniserve_config.clone().random_route;
-        if random_route.is_some() {
+
+        if let Some(random_route) = miniserve_config.clone().random_route {
             addresses.push_str(&format!(
                 "{}",
                 Color::Green
                     .paint(format!(
                         "/{random_route}",
-                        random_route = random_route.unwrap(),
+                        random_route = random_route,
                     ))
                     .bold()
             ));

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,10 +139,7 @@ fn main() {
             addresses.push_str(&format!(
                 "{}",
                 Color::Green
-                    .paint(format!(
-                        "/{random_route}",
-                        random_route = random_route,
-                    ))
+                    .paint(format!("/{random_route}", random_route = random_route,))
                     .bold()
             ));
         }


### PR DESCRIPTION
That's the first of the many PRs I'm going to create. I did lots of changes on errors to make the code cleaner and remove every `unwrap/expect` in the `main()` method so the user gets nice error messages instead of panics. 

However, that would be so many changes in 1 PR that I thought I'll split it in several little PRs, so you can check and correct me. This PR and the next one is more about fixing bugs than actually rethinking the errors.

This PR is about auth, the way it was parsed/checked was not compliant with the RFC. This should do it. Note that this allows empty passwords because the RFC says nothing about it, we could totally forbid it if you want.

For now, I use error messages, but in a later PR, this will return a `ContextualError` with the right error kind. 