### PR TITLE
Wrap title

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -306,6 +306,9 @@ fn css(color_scheme: &ColorScheme) -> Markup {
     .container {{
         padding: 1.5rem 5rem;
     }}
+    .title {{
+        word-break: break-word;
+    }}
     a {{
         text-decoration: none;
     }}


### PR DESCRIPTION
This is a simple fix so the title doesn't overflow when the path is too long. This was especially happening on mobile.
