### PR TITLE
Revamp errors + avoid panics in main()

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -1,6 +1,5 @@
 use actix_web::http::ContentEncoding;
 use bytes::Bytes;
-use failure::ResultExt;
 use libflate::gzip::Encoder;
 use serde::Deserialize;
 use std::io;
@@ -8,7 +7,7 @@ use std::path::PathBuf;
 use strum_macros::{Display, EnumIter, EnumString};
 use tar::Builder;
 
-use crate::errors;
+use crate::errors::{ContextualError, ContextualErrorKind};
 
 /// Available compression methods
 #[derive(Deserialize, Clone, EnumIter, EnumString, Display)]
@@ -47,45 +46,47 @@ pub fn create_archive(
     method: &CompressionMethod,
     dir: &PathBuf,
     skip_symlinks: bool,
-) -> Result<(String, Bytes), errors::CompressionError> {
+) -> Result<(String, Bytes), ContextualError> {
     match method {
         CompressionMethod::TarGz => tgz_compress(&dir, skip_symlinks),
     }
 }
 
 /// Compresses a given folder in .tar.gz format, and returns the result as a stream of bytes
-fn tgz_compress(
-    dir: &PathBuf,
-    skip_symlinks: bool,
-) -> Result<(String, Bytes), errors::CompressionError> {
+fn tgz_compress(dir: &PathBuf, skip_symlinks: bool) -> Result<(String, Bytes), ContextualError> {
     let src_dir = dir.display().to_string();
     let inner_folder = match dir.file_name() {
         Some(directory_name) => match directory_name.to_str() {
             Some(directory) => directory,
             None => {
-                return Err(errors::CompressionError::new(
-                    errors::CompressionErrorKind::InvalidUTF8DirectoryName,
-                ))
+                // https://doc.rust-lang.org/std/ffi/struct.OsStr.html#method.to_str
+                return Err(ContextualError::new(ContextualErrorKind::InvalidPathError(
+                    "Directory name contains invalid UTF-8 characters".to_string(),
+                )));
             }
         },
         None => {
-            return Err(errors::CompressionError::new(
-                errors::CompressionErrorKind::InvalidDirectoryName,
-            ))
+            // https://doc.rust-lang.org/std/path/struct.Path.html#method.file_name
+            return Err(ContextualError::new(ContextualErrorKind::InvalidPathError(
+                "Directory name terminates in \"..\"".to_string(),
+            )));
         }
     };
     let dst_filename = format!("{}.tar", inner_folder);
     let dst_tgz_filename = format!("{}.gz", dst_filename);
 
-    let tar_content = tar(src_dir, inner_folder.to_string(), skip_symlinks).context(
-        errors::CompressionErrorKind::TarBuildingError {
-            message: "an error occured while writing the TAR archive".to_string(),
-        },
-    )?;
-    let gz_data = gzip(&tar_content).context(errors::CompressionErrorKind::GZipBuildingError {
-        message: "an error occured while writing the GZIP archive".to_string(),
+    let tar_content = tar(src_dir, inner_folder.to_string(), skip_symlinks).map_err(|e| {
+        ContextualError::new(ContextualErrorKind::ArchiveCreationError(
+            "tarball".to_string(),
+            Box::new(e),
+        ))
     })?;
-
+    let gz_data = gzip(&tar_content).map_err(|e| {
+        ContextualError::new(ContextualErrorKind::ArchiveCreationError(
+            "GZIP archive".to_string(),
+            Box::new(e),
+        ))
+    })?;
     let mut data = Bytes::new();
     data.extend_from_slice(&gz_data);
 
@@ -97,44 +98,53 @@ fn tar(
     src_dir: String,
     inner_folder: String,
     skip_symlinks: bool,
-) -> Result<Vec<u8>, errors::CompressionError> {
+) -> Result<Vec<u8>, ContextualError> {
     let mut tar_builder = Builder::new(Vec::new());
 
     tar_builder.follow_symlinks(!skip_symlinks);
     // Recursively adds the content of src_dir into the archive stream
-    tar_builder.append_dir_all(inner_folder, &src_dir).context(
-        errors::CompressionErrorKind::TarBuildingError {
-            message: format!(
-                "failed to append the content of {} to the TAR archive",
-                &src_dir
-            ),
-        },
-    )?;
+    tar_builder
+        .append_dir_all(inner_folder, &src_dir)
+        .map_err(|e| {
+            ContextualError::new(ContextualErrorKind::IOError(
+                format!(
+                    "Failed to append the content of {} to the TAR archive",
+                    &src_dir
+                ),
+                e,
+            ))
+        })?;
 
-    let tar_content =
-        tar_builder
-            .into_inner()
-            .context(errors::CompressionErrorKind::TarBuildingError {
-                message: "failed to finish writing the TAR archive".to_string(),
-            })?;
+    let tar_content = tar_builder.into_inner().map_err(|e| {
+        ContextualError::new(ContextualErrorKind::IOError(
+            "Failed to finish writing the TAR archive".to_string(),
+            e,
+        ))
+    })?;
 
     Ok(tar_content)
 }
 
 /// Compresses a stream of bytes using the GZIP algorithm, and returns the resulting stream
-fn gzip(mut data: &[u8]) -> Result<Vec<u8>, errors::CompressionError> {
-    let mut encoder =
-        Encoder::new(Vec::new()).context(errors::CompressionErrorKind::GZipBuildingError {
-            message: "failed to create GZIP encoder".to_string(),
-        })?;
-    io::copy(&mut data, &mut encoder).context(errors::CompressionErrorKind::GZipBuildingError {
-        message: "failed to write GZIP data".to_string(),
+fn gzip(mut data: &[u8]) -> Result<Vec<u8>, ContextualError> {
+    let mut encoder = Encoder::new(Vec::new()).map_err(|e| {
+        ContextualError::new(ContextualErrorKind::IOError(
+            "Failed to create GZIP encoder".to_string(),
+            e,
+        ))
     })?;
-    let data = encoder.finish().into_result().context(
-        errors::CompressionErrorKind::GZipBuildingError {
-            message: "failed to write GZIP trailer".to_string(),
-        },
-    )?;
+    io::copy(&mut data, &mut encoder).map_err(|e| {
+        ContextualError::new(ContextualErrorKind::IOError(
+            "Failed to write GZIP data".to_string(),
+            e,
+        ))
+    })?;
+    let data = encoder.finish().into_result().map_err(|e| {
+        ContextualError::new(ContextualErrorKind::IOError(
+            "Failed to write GZIP trailer".to_string(),
+            e,
+        ))
+    })?;
 
     Ok(data)
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -50,10 +50,12 @@ impl Middleware<crate::MiniserveConfig> for Auth {
                 let auth_req = match parse_basic_auth(auth_headers) {
                     Ok(auth_req) => auth_req,
                     Err(err) => {
-                        return Ok(Response::Done(HttpResponse::BadRequest().body(format!(
-                            "An error occured during HTTP authentication\ncaused by: {}",
-                            err
-                        ))))
+                        let auth_err = ContextualError::new(
+                            ContextualErrorKind::HTTPAuthenticationError(Box::new(err)),
+                        );
+                        return Ok(Response::Done(
+                            HttpResponse::BadRequest().body(auth_err.to_string()),
+                        ));
                     }
                 };
                 if auth_req.username != required_auth.username

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -2,12 +2,9 @@ use actix_web::http::header;
 use actix_web::middleware::{Middleware, Response};
 use actix_web::{HttpRequest, HttpResponse, Result};
 
-pub struct Auth;
+use crate::errors::{ContextualError, ContextualErrorKind};
 
-/// HTTP Basic authentication errors
-pub enum BasicAuthError {
-    Base64DecodeError,
-}
+pub struct Auth;
 
 #[derive(Clone, Debug)]
 /// HTTP Basic authentication parameters
@@ -19,9 +16,17 @@ pub struct BasicAuthParams {
 /// Decode a HTTP basic auth string into a tuple of username and password.
 pub fn parse_basic_auth(
     authorization_header: &header::HeaderValue,
-) -> Result<BasicAuthParams, BasicAuthError> {
-    let basic_removed = authorization_header.to_str().unwrap().replace("Basic ", "");
-    let decoded = base64::decode(&basic_removed).map_err(|_| BasicAuthError::Base64DecodeError)?;
+) -> Result<BasicAuthParams, ContextualError> {
+    let basic_removed = authorization_header
+        .to_str()
+        .map_err(|e| {
+            ContextualError::new(ContextualErrorKind::ParseError(
+                "HTTP authentication header".to_string(),
+                e.to_string(),
+            ))
+        })?
+        .replace("Basic ", "");
+    let decoded = base64::decode(&basic_removed).map_err(ContextualErrorKind::Base64DecodeError)?;
     let decoded_str = String::from_utf8_lossy(&decoded);
     let credentials: Vec<&str> = decoded_str.splitn(2, ':').collect();
 
@@ -44,11 +49,11 @@ impl Middleware<crate::MiniserveConfig> for Auth {
             if let Some(auth_headers) = req.headers().get(header::AUTHORIZATION) {
                 let auth_req = match parse_basic_auth(auth_headers) {
                     Ok(auth_req) => auth_req,
-                    Err(BasicAuthError::Base64DecodeError) => {
+                    Err(err) => {
                         return Ok(Response::Done(HttpResponse::BadRequest().body(format!(
-                            "Error decoding basic auth base64: '{}'",
-                            auth_headers.to_str().unwrap()
-                        ))));
+                            "An error occured during HTTP authentication\ncaused by: {}",
+                            err
+                        ))))
                     }
                 };
                 if auth_req.username != required_auth.username

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,85 +1,69 @@
 use failure::{Backtrace, Context, Fail};
 use std::fmt::{self, Debug, Display};
 
-/// Kinds of errors which might happen during file upload
 #[derive(Debug, Fail)]
-pub enum FileUploadErrorKind {
-    /// This error will occur when file overriding is off and a file with same name already exists
-    #[fail(display = "File with this name already exists")]
-    FileExist,
-    /// This error will occur when the server fails to process the HTTP header during file upload
-    #[fail(display = "Failed to parse incoming request")]
-    ParseError,
-    /// This error will occur when we fail to process the multipart request
-    #[fail(display = "Failed to process multipart request")]
+pub enum ContextualErrorKind {
+    /// Fully customized errors, not inheriting from any error
+    #[fail(display = "{}", _0)]
+    CustomError(String),
+
+    /// Any kind of IO errors
+    #[fail(display = "{}\ncaused by: {}", _0, _1)]
+    IOError(String, std::io::Error),
+
+    /// MultipartError, which might occur during file upload, when processing the multipart request fails
+    #[fail(display = "Failed to process multipart request\ncaused by: {}", _0)]
     MultipartError(actix_web::error::MultipartError),
-    /// This error may occur when trying to write the incoming file to disk
-    #[fail(display = "Failed to create or write to file")]
-    IOError(std::io::Error),
-    /// This error will occur when we he have insuffictent permissions to create new file
-    #[fail(display = "Insufficient permissions to create file")]
-    InsufficientPermissions,
-}
 
-/// Kinds of errors which might happen during the generation of an archive
-#[derive(Debug, Fail)]
-pub enum CompressionErrorKind {
-    /// This error will occur if the directory name could not be retrieved from the path
-    /// See https://doc.rust-lang.org/std/path/struct.Path.html#method.file_name
-    #[fail(display = "Invalid path: directory name terminates in \"..\"")]
-    InvalidDirectoryName,
-    /// This error will occur when trying to convert an OSString into a String, if the path
-    /// contains invalid UTF-8 characters
-    /// See https://doc.rust-lang.org/std/ffi/struct.OsStr.html#method.to_str
-    #[fail(display = "Invalid path: directory name contains invalid UTF-8 characters")]
-    InvalidUTF8DirectoryName,
-    /// This error might occur while building a TAR archive, or while writing the termination sections
-    /// See https://docs.rs/tar/0.4.22/tar/struct.Builder.html#method.append_dir_all
-    /// and https://docs.rs/tar/0.4.22/tar/struct.Builder.html#method.into_inner
-    #[fail(display = "Failed to create the TAR archive: {}", message)]
-    TarBuildingError { message: String },
-    /// This error might occur while building a GZIP archive, or while writing the GZIP trailer
-    /// See https://docs.rs/libflate/0.1.21/libflate/gzip/struct.Encoder.html#method.finish
-    #[fail(display = "Failed to create the GZIP archive: {}", message)]
-    GZipBuildingError { message: String },
-}
+    /// This error might occur when decoding the HTTP authentication header.
+    #[fail(
+        display = "Failed to decode HTTP authentication header\ncaused by: {}",
+        _0
+    )]
+    Base64DecodeError(base64::DecodeError),
 
-/// Prints the full chain of error, up to the root cause.
-/// If RUST_BACKTRACE is set to 1, also prints the backtrace for each error
-pub fn print_error_chain(err: CompressionError) {
-    log::error!("{}", &err);
-    print_backtrace(&err);
-    for cause in Fail::iter_causes(&err) {
-        log::error!("caused by: {}", cause);
-        print_backtrace(cause);
-    }
-}
+    /// Any error related to an invalid path (failed to retrieve entry name, unexpected entry type, etc)
+    #[fail(display = "Invalid path\ncaused by: {}", _0)]
+    InvalidPathError(String),
 
-/// Prints the backtrace of an error
-/// RUST_BACKTRACE needs to be set to 1 to display the backtrace
-fn print_backtrace(err: &dyn Fail) {
-    if let Some(backtrace) = err.backtrace() {
-        let backtrace = backtrace.to_string();
-        if backtrace != "" {
-            log::error!("{}", backtrace);
-        }
-    }
+    /// This error might occur if the HTTP credential string does not respect the expected format
+    #[fail(display = "Invalid format for credentials string. Expected is username:format")]
+    InvalidAuthFormat,
+
+    /// This error might occur if the HTTP auth password exceeds 255 characters
+    #[fail(display = "HTTP password length exceeds 255 characters")]
+    PasswordTooLongError,
+
+    /// This error might occur if the user has unsufficient permissions to create an entry in a given directory
+    #[fail(display = "Insufficient permissions to create file in {}", _0)]
+    InsufficientPermissionsError(String),
+
+    /// Any error related to parsing.
+    #[fail(display = "Failed to parse {}\ncaused by: {}", _0, _1)]
+    ParseError(String, String),
+
+    /// This error might occur when the creation of an archive fails
+    #[fail(
+        display = "An error occured while creating the {}\ncaused by: {}",
+        _0, _1
+    )]
+    ArchiveCreationError(String, Box<ContextualError>),
 }
 
 /// Based on https://boats.gitlab.io/failure/error-errorkind.html
-pub struct CompressionError {
-    inner: Context<CompressionErrorKind>,
+pub struct ContextualError {
+    inner: Context<ContextualErrorKind>,
 }
 
-impl CompressionError {
-    pub fn new(kind: CompressionErrorKind) -> CompressionError {
-        CompressionError {
+impl ContextualError {
+    pub fn new(kind: ContextualErrorKind) -> ContextualError {
+        ContextualError {
             inner: Context::new(kind),
         }
     }
 }
 
-impl Fail for CompressionError {
+impl Fail for ContextualError {
     fn cause(&self) -> Option<&Fail> {
         self.inner.cause()
     }
@@ -89,28 +73,35 @@ impl Fail for CompressionError {
     }
 }
 
-impl Display for CompressionError {
+impl Display for ContextualError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         Display::fmt(&self.inner, f)
     }
 }
 
-impl Debug for CompressionError {
+impl Debug for ContextualError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         Debug::fmt(&self.inner, f)
     }
 }
 
-impl From<Context<CompressionErrorKind>> for CompressionError {
-    fn from(inner: Context<CompressionErrorKind>) -> CompressionError {
-        CompressionError { inner }
+impl From<Context<ContextualErrorKind>> for ContextualError {
+    fn from(inner: Context<ContextualErrorKind>) -> ContextualError {
+        ContextualError { inner }
     }
 }
 
-impl From<CompressionErrorKind> for CompressionError {
-    fn from(kind: CompressionErrorKind) -> CompressionError {
-        CompressionError {
+impl From<ContextualErrorKind> for ContextualError {
+    fn from(kind: ContextualErrorKind) -> ContextualError {
+        ContextualError {
             inner: Context::new(kind),
         }
+    }
+}
+
+/// This allows to create CustomErrors more simply
+impl From<String> for ContextualError {
+    fn from(msg: String) -> ContextualError {
+        ContextualError::new(ContextualErrorKind::CustomError(msg))
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -50,6 +50,12 @@ pub enum ContextualErrorKind {
     ArchiveCreationError(String, Box<ContextualError>),
 }
 
+pub fn log_error_chain(description: String) {
+    for cause in description.lines() {
+        log::error!("{}", cause);
+    }
+}
+
 /// Based on https://boats.gitlab.io/failure/error-errorkind.html
 pub struct ContextualError {
     inner: Context<ContextualErrorKind>,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -48,6 +48,13 @@ pub enum ContextualErrorKind {
         _0, _1
     )]
     ArchiveCreationError(String, Box<ContextualError>),
+
+    /// This error might occur when the HTTP authentication fails
+    #[fail(
+        display = "An error occured during HTTP authentication\ncaused by: {}",
+        _0
+    )]
+    HTTPAuthenticationError(Box<ContextualError>),
 }
 
 pub fn log_error_chain(description: String) {

--- a/src/file_upload.rs
+++ b/src/file_upload.rs
@@ -175,6 +175,7 @@ fn create_error_response(
     description: &str,
     return_path: &str,
 ) -> FutureResult<HttpResponse, actix_web::error::Error> {
+    log::error!("{}", description);
     future::ok(
         HttpResponse::BadRequest()
             .content_type("text/html; charset=utf-8")

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -10,7 +10,6 @@ use std::time::SystemTime;
 use strum_macros::{Display, EnumString};
 
 use crate::archive;
-use crate::errors;
 use crate::renderer;
 use crate::themes;
 
@@ -263,10 +262,9 @@ pub fn directory_listing<S>(
                     .body(Body::Streaming(Box::new(once(Ok(content))))))
             }
             Err(err) => {
-                errors::print_error_chain(err);
                 Ok(HttpResponse::Ok()
                     .status(http::StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(""))
+                    .body(err.to_string()))
             }
         }
     } else {

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -261,11 +261,9 @@ pub fn directory_listing<S>(
                     .chunked()
                     .body(Body::Streaming(Box::new(once(Ok(content))))))
             }
-            Err(err) => {
-                Ok(HttpResponse::Ok()
-                    .status(http::StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(err.to_string()))
-            }
+            Err(err) => Ok(HttpResponse::Ok()
+                .status(http::StatusCode::INTERNAL_SERVER_ERROR)
+                .body(err.to_string())),
         }
     } else {
         Ok(HttpResponse::Ok()

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -10,9 +10,9 @@ use std::time::SystemTime;
 use strum_macros::{Display, EnumString};
 
 use crate::archive;
+use crate::errors;
 use crate::renderer;
 use crate::themes;
-use crate::errors;
 
 /// Query parameters
 #[derive(Deserialize)]
@@ -266,7 +266,7 @@ pub fn directory_listing<S>(
                 errors::log_error_chain(err.to_string());
                 Ok(HttpResponse::Ok()
                     .status(http::StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(renderer::render_error(&err.to_string(), serve_path).into_string())
+                    .body(renderer::render_error(&err.to_string(), serve_path).into_string()))
             }
         }
     } else {

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -12,6 +12,7 @@ use strum_macros::{Display, EnumString};
 use crate::archive;
 use crate::renderer;
 use crate::themes;
+use crate::errors;
 
 /// Query parameters
 #[derive(Deserialize)]
@@ -262,10 +263,10 @@ pub fn directory_listing<S>(
                     .body(Body::Streaming(Box::new(once(Ok(content))))))
             }
             Err(err) => {
-                log::error!("{}", &err);
+                errors::log_error_chain(err.to_string());
                 Ok(HttpResponse::Ok()
                     .status(http::StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(err.to_string()))
+                    .body(renderer::render_error(&err.to_string(), serve_path).into_string())
             }
         }
     } else {

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -261,9 +261,12 @@ pub fn directory_listing<S>(
                     .chunked()
                     .body(Body::Streaming(Box::new(once(Ok(content))))))
             }
-            Err(err) => Ok(HttpResponse::Ok()
-                .status(http::StatusCode::INTERNAL_SERVER_ERROR)
-                .body(err.to_string())),
+            Err(err) => {
+                log::error!("{}", &err);
+                Ok(HttpResponse::Ok()
+                    .status(http::StatusCode::INTERNAL_SERVER_ERROR)
+                    .body(err.to_string()))
+            }
         }
     } else {
         Ok(HttpResponse::Ok()

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ pub struct MiniserveConfig {
 fn main() {
     match run() {
         Ok(()) => (),
-        Err(e) => eprintln!("\n{}\n", Paint::red(e)),
+        Err(e) => errors::log_error_chain(e.to_string()),
     }
 }
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -761,7 +761,7 @@ fn humanize_systemtime(src_time: Option<SystemTime>) -> Option<String> {
 }
 
 /// Renders error page when file uploading fails
-pub fn file_upload_error(error_description: &str, return_address: &str) -> Markup {
+pub fn render_error(error_description: &str, return_address: &str) -> Markup {
     html! {
         pre { (error_description) }
         a href=(return_address) {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -760,7 +760,7 @@ fn humanize_systemtime(src_time: Option<SystemTime>) -> Option<String> {
         .map(|duration| HumanTime::from(duration).to_text_en(Accuracy::Rough, Tense::Past))
 }
 
-/// Renders error page when file uploading fails
+/// Renders an error on the webpage
 pub fn render_error(error_description: &str, return_address: &str) -> Markup {
     html! {
         pre { (error_description) }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -47,7 +47,7 @@ pub fn page(
                             form id="file_submit" action={(upload_route) "?path=" (current_dir)} method="POST" enctype="multipart/form-data" {
                                 p { "Select a file to upload or drag it anywhere into the window" }
                                 div {
-                                    input#file-input type="file" name="file_to_upload" {}
+                                    input#file-input type="file" name="file_to_upload" required="" {}
                                     button type="submit" { "Upload file" }
                                 }
                             }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -763,8 +763,7 @@ fn humanize_systemtime(src_time: Option<SystemTime>) -> Option<String> {
 /// Renders error page when file uploading fails
 pub fn file_upload_error(error_description: &str, return_address: &str) -> Markup {
     html! {
-        h1 { "File uploading failed" }
-        p { (error_description) }
+        pre { (error_description) }
         a href=(return_address) {
             "Go back to file listing"
         }


### PR DESCRIPTION
So, this is an attempt to rework the error system and avoid panics in the main() function (1). I did quite a lot of changes. I especially tried to have more general errors (with parameters) instead of creating specific errors for each case. I took example at burntsushi's codebase, he does that a lot.

What also changed is that now the error chain is also printed on the webpage (because that's where the user is), for upload and download errors. Note that it does not use the `failure` chaining system for now. Hopefully, it's just temporary, I wish I could use it but it seems that it's a bit harder than what I expected (it seems I'm not the only one: https://github.com/rust-lang-nursery/failure/issues/189). The way I did it right now is not elegant, but it works. If you think using the `failure` chaining system for this is mandatory, I'll keep digging obviously.

I will try to add some tests, in the scope of this PR (hence the WIP), since some errors can be quite easily emulated, so it's not that expensive to add some tests for them.

(1) There's 1 expect I am unable to remove, but it's also a case where panic can be a reasonable solution (main.rs:254)