### PR TITLE
Add hashed password to integration test

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -90,10 +90,13 @@ fn serves_requests_with_non_default_port(tmpdir: TempDir, port: u16) -> Result<(
         "testpassword"
     ),
 )]
-fn auth_works(cli_auth_arg: &str, client_username: &str, client_password: &str) -> Result<(), Error> {
-    let tmpdir = self::tmpdir();
-    let port = self::port();
-
+fn auth_works(
+    tmpdir: TempDir,
+    port: u16,
+    cli_auth_arg: &str,
+    client_username: &str,
+    client_password: &str
+) -> Result<(), Error> {
     let mut child = Command::cargo_bin("miniserve")?
         .arg(tmpdir.path())
         .arg("-p")

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -11,6 +11,7 @@ use select::predicate::{Attr, Text};
 use std::process::{Command, Stdio};
 use std::thread::sleep;
 use std::time::Duration;
+use rstest::rstest_parametrize;
 
 type Error = Box<std::error::Error>;
 
@@ -75,14 +76,30 @@ fn serves_requests_with_non_default_port(tmpdir: TempDir, port: u16) -> Result<(
     Ok(())
 }
 
-#[rstest]
-fn auth_works(tmpdir: TempDir, port: u16) -> Result<(), Error> {
+#[rstest_parametrize(
+    cli_auth_arg, client_username, client_password,
+    case("testuser:testpassword", "testuser", "testpassword"),
+    case(
+        "testuser:sha256:9f735e0df9a1ddc702bf0a1a7b83033f9f7153a00c29de82cedadc9957289b05",
+        "testuser",
+        "testpassword"
+    ),
+    case(
+        "testuser:sha512:e9e633097ab9ceb3e48ec3f70ee2beba41d05d5420efee5da85f97d97005727587fda33ef4ff2322088f4c79e8133cc9cd9f3512f4d3a303cbdb5bc585415a00",
+        "testuser",
+        "testpassword"
+    ),
+)]
+fn auth_works(cli_auth_arg: &str, client_username: &str, client_password: &str) -> Result<(), Error> {
+    let tmpdir = self::tmpdir();
+    let port = self::port();
+
     let mut child = Command::cargo_bin("miniserve")?
         .arg(tmpdir.path())
         .arg("-p")
         .arg(port.to_string())
         .arg("-a")
-        .arg("testuser:testpassword")
+        .arg(cli_auth_arg)
         .stdout(Stdio::null())
         .spawn()?;
 
@@ -91,7 +108,7 @@ fn auth_works(tmpdir: TempDir, port: u16) -> Result<(), Error> {
     let client = reqwest::Client::new();
     let body = client
         .get(format!("http://localhost:{}", port).as_str())
-        .basic_auth("testuser", Some("testpassword"))
+        .basic_auth(client_username, Some(client_password))
         .send()?
         .error_for_status()?;
     let parsed = Document::from_read(body)?;


### PR DESCRIPTION
## Missing

* Tests where it rejects (user logs in with wrong username and/or password)
* Tests where value of `--auth` is not valid