### PR TITLE
Move 'rust: [stable, beta]' into 'matrix.includes'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: rust
 dist: xenial
 
-rust:
-  - stable
-  - beta
-  - nightly
+rust: []
+env: []
 
 addons:
   apt:
@@ -20,6 +18,9 @@ matrix:
     - rust: stable
     - rust: beta
   include:
+    - rust: stable
+    - rust: beta
+    - rust: nightly
     - rust: nightly
       env:
         - TARGET=x86_64-unknown-linux-musl

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,16 @@ addons:
 matrix:
   allow_failures:
     - rust: stable
+      env: []
     - rust: beta
+      env: []
   include:
     - rust: stable
+      env: []
     - rust: beta
+      env: []
     - rust: nightly
+      env: []
     - rust: nightly
       env:
         - TARGET=x86_64-unknown-linux-musl


### PR DESCRIPTION
## Reasons

* I think it is less confusing that we do not specify global `rust` versions
* This enable me to do [what I want](https://github.com/svenstaro/miniserve/pull/94#issuecomment-488231000) with Clippy.