### PR TITLE
Add assertion of status code to auth_works

### DIFF
--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -9,6 +9,7 @@ use select::predicate::Text;
 use std::process::{Command, Stdio};
 use std::thread::sleep;
 use std::time::Duration;
+use reqwest::StatusCode;
 
 #[rstest_parametrize(
     cli_auth_arg, client_username, client_password,
@@ -49,7 +50,7 @@ fn auth_works(
         .send()?;
 
     let status_code = response.status();
-    assert_eq!(status_code.canonical_reason(), Some("OK"));
+    assert_eq!(status_code, StatusCode::OK);
 
     let body = response.error_for_status()?;
     let parsed = Document::from_read(body)?;

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -43,11 +43,15 @@ fn auth_works(
     sleep(Duration::from_secs(1));
 
     let client = reqwest::Client::new();
-    let body = client
+    let response = client
         .get(format!("http://localhost:{}", port).as_str())
         .basic_auth(client_username, Some(client_password))
-        .send()?
-        .error_for_status()?;
+        .send()?;
+
+    let status_code = response.status();
+    assert_eq!(status_code.canonical_reason(), Some("OK"));
+
+    let body = response.error_for_status()?;
     let parsed = Document::from_read(body)?;
     for &file in FILES {
         assert!(parsed.find(Text).any(|x| x.text() == file));


### PR DESCRIPTION
I would even argue that checking for status code is enough, that parsing HTML and accessing every file is irrelevant and unnecessary, and in order to speed up the test, we should delete the irrelevant part.