### PR TITLE
Add example for --auth formatting

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -40,6 +40,7 @@ struct CLIArgs {
 
     /// Set authentication. Currently supported formats:
     /// username:password, username:sha256:hash, username:sha512:hash
+    /// (e.g. joe:123, joe:sha256:a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3)
     #[structopt(short = "a", long = "auth", parse(try_from_str = "parse_auth"))]
     auth: Option<auth::RequiredAuth>,
 


### PR DESCRIPTION
I just noticed that `--help` message regarding hashed password of `--auth` is kind of vague: It does not tell user which format should `hash` be in (hexadecimal, base64, array of decimals). This PR should clear that confusion.