### PR TITLE
Fix Clippy warnings + cargo fmt

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use strum_macros::{Display, EnumIter, EnumString};
 use tar::Builder;
 
-use crate::errors::{ContextualError};
+use crate::errors::ContextualError;
 
 /// Available compression methods
 #[derive(Deserialize, Clone, EnumIter, EnumString, Display)]
@@ -62,17 +62,11 @@ fn tgz_compress(dir: &PathBuf, skip_symlinks: bool) -> Result<(String, Bytes), C
             let mut tgz_data = Bytes::new();
 
             let tar_data = tar(src_dir, directory.to_string(), skip_symlinks).map_err(|e| {
-                ContextualError::ArchiveCreationError(
-                    "tarball".to_string(),
-                    Box::new(e),
-                )
+                ContextualError::ArchiveCreationError("tarball".to_string(), Box::new(e))
             })?;
 
             let gz_data = gzip(&tar_data).map_err(|e| {
-                ContextualError::ArchiveCreationError(
-                    "GZIP archive".to_string(),
-                    Box::new(e),
-                )
+                ContextualError::ArchiveCreationError("GZIP archive".to_string(), Box::new(e))
             })?;
 
             tgz_data.extend_from_slice(&gz_data);
@@ -115,10 +109,7 @@ fn tar(
         })?;
 
     let tar_content = tar_builder.into_inner().map_err(|e| {
-        ContextualError::IOError(
-            "Failed to finish writing the TAR archive".to_string(),
-            e,
-        )
+        ContextualError::IOError("Failed to finish writing the TAR archive".to_string(), e)
     })?;
 
     Ok(tar_content)
@@ -126,24 +117,14 @@ fn tar(
 
 /// Compresses a stream of bytes using the GZIP algorithm, and returns the resulting stream
 fn gzip(mut data: &[u8]) -> Result<Vec<u8>, ContextualError> {
-    let mut encoder = Encoder::new(Vec::new()).map_err(|e| {
-        ContextualError::IOError(
-            "Failed to create GZIP encoder".to_string(),
-            e,
-        )
-    })?;
-    io::copy(&mut data, &mut encoder).map_err(|e| {
-        ContextualError::IOError(
-            "Failed to write GZIP data".to_string(),
-            e,
-        )
-    })?;
-    let data = encoder.finish().into_result().map_err(|e| {
-        ContextualError::IOError(
-            "Failed to write GZIP trailer".to_string(),
-            e,
-        )
-    })?;
+    let mut encoder = Encoder::new(Vec::new())
+        .map_err(|e| ContextualError::IOError("Failed to create GZIP encoder".to_string(), e))?;
+    io::copy(&mut data, &mut encoder)
+        .map_err(|e| ContextualError::IOError("Failed to write GZIP data".to_string(), e))?;
+    let data = encoder
+        .finish()
+        .into_result()
+        .map_err(|e| ContextualError::IOError("Failed to write GZIP trailer".to_string(), e))?;
 
     Ok(data)
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 
 use crate::auth;
-use crate::errors::{ContextualError};
+use crate::errors::ContextualError;
 use crate::themes;
 
 /// Possible characters for random routes
@@ -99,15 +99,13 @@ fn parse_auth(src: &str) -> Result<auth::RequiredAuth, ContextualError> {
         let hash_bin = if let Ok(hash_bin) = hex::decode(hash_hex) {
             hash_bin
         } else {
-            return Err(ContextualError::InvalidPasswordHash)
+            return Err(ContextualError::InvalidPasswordHash);
         };
 
         match second_part {
             "sha256" => auth::RequiredAuthPassword::Sha256(hash_bin.to_owned()),
             "sha512" => auth::RequiredAuthPassword::Sha512(hash_bin.to_owned()),
-            _ => {
-                return Err(ContextualError::InvalidHashMethod(second_part.to_owned()))
-            },
+            _ => return Err(ContextualError::InvalidHashMethod(second_part.to_owned())),
         }
     } else {
         // To make it Windows-compatible, the password needs to be shorter than 255 characters.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -32,7 +32,10 @@ pub enum ContextualError {
     InvalidAuthFormat,
 
     /// This error might occure if the hash method is neither sha256 nor sha512
-    #[fail(display = "{} is not a valid hashing method. Expected sha256 or sha512", _0)]
+    #[fail(
+        display = "{} is not a valid hashing method. Expected sha256 or sha512",
+        _0
+    )]
     InvalidHashMethod(String),
 
     /// This error might occur if the HTTP auth hash password is not a valid hex code

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,9 +83,7 @@ fn run() -> Result<(), ContextualError> {
         && miniserve_config
             .path
             .symlink_metadata()
-            .map_err(|e| {
-                ContextualError::IOError("Failed to retrieve symlink's metadata".to_string(), e)
-            })?
+            .map_err(|e| ContextualError::IOError("Failed to retrieve symlink's metadata".to_string(), e))?
             .file_type()
             .is_symlink()
     {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -846,6 +846,7 @@ fn humanize_systemtime(src_time: Option<SystemTime>) -> Option<String> {
 }
 
 /// Renders an error on the webpage
+#[allow(clippy::too_many_arguments)]
 pub fn render_error(
     error_description: &str,
     error_code: StatusCode,

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -3,13 +3,13 @@ mod fixtures;
 use assert_cmd::prelude::*;
 use assert_fs::fixture::TempDir;
 use fixtures::{port, tmpdir, Error, FILES};
+use reqwest::StatusCode;
 use rstest::rstest_parametrize;
 use select::document::Document;
 use select::predicate::Text;
 use std::process::{Command, Stdio};
 use std::thread::sleep;
 use std::time::Duration;
-use reqwest::StatusCode;
 
 #[rstest_parametrize(
     cli_auth_arg, client_username, client_password,


### PR DESCRIPTION
So, I just ran `cargo fmt` and fixed `clippy`'s warning the easiest way possible, just so that master turns green. I think that in the case of too many arguments, allowing it is probably cleaner than creating specific struct just for that, especially for the `render_error` method, which must be called a dozen times... But if you decide that a struct would be cleaner, that's not an expensive fix to do, my priority was just to make master turn green. 