### PR TITLE
Enable streaming tarball download

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -85,7 +85,26 @@ where
 /// Write a tarball of `dir` in `out`.
 ///
 /// The target directory will be saved as a top-level directory in the archive.
-/// For example, if given `"a/b/c"`, it will be stored as just `"c"` in the archive.
+///
+/// For example, consider this directory structure:
+///
+/// ```
+/// a
+/// └── b
+///     └── c
+///         ├── e
+///         ├── f
+///         └── g
+/// ```
+///
+/// Making a tarball out of `"a/b/c"` will result in this archive content:
+///
+/// ```
+/// c
+/// ├── e
+/// ├── f
+/// └── g
+/// ```
 fn tar_dir<W>(dir: &Path, skip_symlinks: bool, out: W) -> Result<(), ContextualError>
 where
     W: std::io::Write,

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -1,7 +1,7 @@
-use actix_web::http::StatusCode;
-use actix_web::{fs, http, Body, FromRequest, HttpRequest, HttpResponse, Query, Result};
+use actix_web::{fs, Body, FromRequest, HttpRequest, HttpResponse, Query, Result};
 use bytesize::ByteSize;
-use futures::stream::once;
+use failure::Fail;
+use futures::Stream;
 use htmlescape::encode_minimal as escape_html_entity;
 use percent_encoding::{utf8_percent_encode, DEFAULT_ENCODE_SET};
 use serde::Deserialize;
@@ -235,46 +235,46 @@ pub fn directory_listing<S>(
 
     let color_scheme = query_params.theme.unwrap_or(default_color_scheme);
 
-    if let Some(compression_method) = &query_params.download {
+    if let Some(compression_method) = query_params.download {
         log::info!(
             "Creating an archive ({extension}) of {path}...",
             extension = compression_method.extension(),
             path = &dir.path.display().to_string()
         );
-        match compression_method.create_archive(&dir.path, skip_symlinks) {
-            Ok((filename, content)) => {
-                log::info!("{file} successfully created !", file = &filename);
-                Ok(HttpResponse::Ok()
-                    .content_type(compression_method.content_type())
-                    .content_encoding(compression_method.content_encoding())
-                    .header("Content-Transfer-Encoding", "binary")
-                    .header(
-                        "Content-Disposition",
-                        format!("attachment; filename={:?}", filename),
-                    )
-                    .chunked()
-                    .body(Body::Streaming(Box::new(once(Ok(content))))))
+
+        let filename = format!(
+            "{}.{}",
+            dir.path.file_name().unwrap().to_str().unwrap(),
+            compression_method.extension()
+        );
+
+        // Create a pipe to connect the archive creation thread and the response.
+        // Include 10 messages of buffer for erratic connection speeds.
+        let (tx, rx) = futures::sync::mpsc::channel(10);
+        let pipe = crate::pipe::Pipe::new(tx);
+
+        // Start the actual archive creation in a separate thread.
+        let dir = dir.path.to_path_buf();
+        std::thread::spawn(move || {
+            if let Err(err) = compression_method.create_archive(dir, skip_symlinks, pipe) {
+                log::error!("Error during archive creation: {:?}", err);
             }
-            Err(err) => {
-                errors::log_error_chain(err.to_string());
-                Ok(HttpResponse::Ok()
-                    .status(http::StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(
-                        renderer::render_error(
-                            &err.to_string(),
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            serve_path,
-                            query_params.sort,
-                            query_params.order,
-                            color_scheme,
-                            default_color_scheme,
-                            false,
-                            true,
-                        )
-                        .into_string(),
-                    ))
-            }
-        }
+        });
+
+        // `<rx as Stream>::Error == ()` but we want `actix_web::error::Error`
+        // It can't happen, so let's just please the type checker.
+        let rx = rx.map_err(|_| unreachable!("pipes never fail"));
+
+        Ok(HttpResponse::Ok()
+            .content_type(compression_method.content_type())
+            .content_encoding(compression_method.content_encoding())
+            .header("Content-Transfer-Encoding", "binary")
+            .header(
+                "Content-Disposition",
+                format!("attachment; filename={:?}", filename),
+            )
+            .chunked()
+            .body(Body::Streaming(Box::new(rx))))
     } else {
         Ok(HttpResponse::Ok()
             .content_type("text/html; charset=utf-8")
@@ -302,7 +302,7 @@ pub fn extract_query_parameters<S>(req: &HttpRequest<S>) -> QueryParameters {
         Ok(query) => QueryParameters {
             sort: query.sort,
             order: query.order,
-            download: query.download.clone(),
+            download: query.download,
             theme: query.theme,
             path: query.path.clone(),
         },

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -1,0 +1,40 @@
+use bytes::{Bytes, BytesMut};
+use futures::sink::{Sink, Wait};
+use futures::sync::mpsc::Sender;
+use std::io::{Error, ErrorKind, Result, Write};
+
+pub struct Pipe {
+    dest: Wait<Sender<Bytes>>,
+    bytes: BytesMut,
+}
+
+impl Pipe {
+    pub fn new(destination: Sender<Bytes>) -> Self {
+        Pipe {
+            dest: destination.wait(),
+            bytes: BytesMut::new(),
+        }
+    }
+}
+
+impl Drop for Pipe {
+    fn drop(&mut self) {
+        let _ = self.dest.close();
+    }
+}
+
+impl Write for Pipe {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        self.bytes.extend_from_slice(buf);
+        match self.dest.send(self.bytes.take().into()) {
+            Ok(_) => Ok(buf.len()),
+            Err(e) => Err(Error::new(ErrorKind::UnexpectedEof, e)),
+        }
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        self.dest
+            .flush()
+            .map_err(|e| Error::new(ErrorKind::UnexpectedEof, e))
+    }
+}

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -1,3 +1,4 @@
+//! Define an adapter to implement `std::io::Write` on `Sender<Bytes>`.
 use bytes::{Bytes, BytesMut};
 use futures::sink::{Sink, Wait};
 use futures::sync::mpsc::Sender;

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -3,12 +3,18 @@ use futures::sink::{Sink, Wait};
 use futures::sync::mpsc::Sender;
 use std::io::{Error, ErrorKind, Result, Write};
 
+/// Adapter to implement the `std::io::Write` trait on a `Sender<Bytes>` from a futures channel.
+///
+/// It uses an intermediate buffer to transfer packets.
 pub struct Pipe {
+    // Wrapping the sender in `Wait` makes it blocking, so we can implement blocking-style
+    // io::Write over the async-style Sender.
     dest: Wait<Sender<Bytes>>,
     bytes: BytesMut,
 }
 
 impl Pipe {
+    /// Wrap the given sender in a `Pipe`.
     pub fn new(destination: Sender<Bytes>) -> Self {
         Pipe {
             dest: destination.wait(),
@@ -19,17 +25,24 @@ impl Pipe {
 
 impl Drop for Pipe {
     fn drop(&mut self) {
+        // This is the correct thing to do, but is not super important since the `Sink`
+        // implementation of `Sender` just returns `Ok` without doing anything else.
         let _ = self.dest.close();
     }
 }
 
 impl Write for Pipe {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        // We are given a slice of bytes we do not own, so we must start by copying it.
         self.bytes.extend_from_slice(buf);
-        match self.dest.send(self.bytes.take().into()) {
-            Ok(_) => Ok(buf.len()),
-            Err(e) => Err(Error::new(ErrorKind::UnexpectedEof, e)),
-        }
+
+        // Then, take the buffer and send it in the channel.
+        self.dest
+            .send(self.bytes.take().into())
+            .map_err(|e| Error::new(ErrorKind::UnexpectedEof, e))?;
+
+        // Return how much we sent - all of it.
+        Ok(buf.len())
     }
 
     fn flush(&mut self) -> Result<()> {


### PR DESCRIPTION
This PR:

* Adds `src/pipe.rs` to provide a `Write` implementation on a `mpsc::Sender<Bytes>`.
* Make `CompressionMethod: Copy`
* Updates `src/archive.rs` to take a `W: Write` as argument rather than returning a byte array.
* Updates `src/listing.rs` to, when a archive is requested:
    * Create a channel of `Bytes` (with a capacity of 10 to give some buffer between compression and upload)
    * Start a new thread, and run `create_archive` in this thread with the `Write` side of the pipe
    * Return an actix response streaming the read side of the pipe
* Adds `CompressionMethod::Tar` for uncompressed archive

The net result is that archive download (either tar or tar.gz) now starts immediately and uses a more reasonable amount of memory on the host. In particular, downloading folders larger than the memory of the host is now possible.

Fixes #2 