### PR TITLE
Add abillity to set path prefix

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -51,9 +51,9 @@ struct CLIArgs {
     )]
     auth: Vec<auth::RequiredAuth>,
 
-    /// Generate a random 6-hexdigit route
-    #[structopt(long = "random-route")]
-    random_route: bool,
+    /// Use a specific path prefix
+    #[structopt(long = "path-prefix")]
+    path_prefix: Option<String>,
 
     /// Do not follow symbolic links
     #[structopt(short = "P", long = "no-symlinks")]
@@ -142,11 +142,7 @@ pub fn parse_args() -> crate::MiniserveConfig {
         ]
     };
 
-    let random_route = if args.random_route {
-        Some(nanoid::custom(6, &ROUTE_ALPHABET))
-    } else {
-        None
-    };
+    let path_prefix = args.path_prefix;
 
     let default_color_scheme = args.color_scheme;
 
@@ -160,7 +156,7 @@ pub fn parse_args() -> crate::MiniserveConfig {
         auth: args.auth,
         path_explicitly_chosen,
         no_symlinks: args.no_symlinks,
-        random_route,
+        path_prefix,
         default_color_scheme,
         overwrite_files: args.overwrite_files,
         file_upload: args.file_upload,

--- a/src/args.rs
+++ b/src/args.rs
@@ -146,7 +146,11 @@ pub fn parse_args() -> crate::MiniserveConfig {
         ]
     };
 
-    let path_prefix = args.path_prefix;
+    let path_prefix = if args.random_path_prefix {
+        Some(nanoid::custom(6, &ROUTE_ALPHABET))
+    } else {
+        args.path_prefix
+    };
 
     let default_color_scheme = args.color_scheme;
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -55,6 +55,10 @@ struct CLIArgs {
     #[structopt(long = "path-prefix")]
     path_prefix: Option<String>,
 
+    /// Use a random path prefix
+    #[structopt(long = "random-path-prefix", conflicts_with("path-prefix"))]
+    random_path_prefix: bool,
+
     /// Do not follow symbolic links
     #[structopt(short = "P", long = "no-symlinks")]
     no_symlinks: bool,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -145,8 +145,8 @@ fn build_unauthorized_response(
     if log_error_chain {
         errors::log_error_chain(error.to_string());
     }
-    let return_path = match &req.state().random_route {
-        Some(random_route) => format!("/{}", random_route),
+    let return_path = match &req.state().path_prefix {
+        Some(path_prefix) => format!("/{}", path_prefix),
         None => "/".to_string(),
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,8 +45,8 @@ pub struct MiniserveConfig {
     /// Enable symlink resolution
     pub no_symlinks: bool,
 
-    /// Enable random route generation
-    pub random_route: Option<String>,
+    /// Enable URL path prefix
+    pub path_prefix: Option<String>,
 
     /// Default color scheme
     pub default_color_scheme: themes::ColorScheme,
@@ -169,12 +169,10 @@ fn run() -> Result<(), ContextualError> {
                 .bold()
         ));
 
-        if let Some(random_route) = miniserve_config.clone().random_route {
+        if let Some(path_prefix) = miniserve_config.clone().path_prefix {
             addresses.push_str(&format!(
                 "{}",
-                Color::Green
-                    .paint(format!("/{random_route}", random_route = random_route,))
-                    .bold()
+                Color::Green.paint(format!("/{}", path_prefix)).bold()
             ));
         }
     }
@@ -234,11 +232,11 @@ fn configure_app(app: App<MiniserveConfig>) -> App<MiniserveConfig> {
     let s = {
         let path = &app.state().path;
         let no_symlinks = app.state().no_symlinks;
-        let random_route = app.state().random_route.clone();
+        let path_prefix = app.state().path_prefix.clone();
         let default_color_scheme = app.state().default_color_scheme;
         let file_upload = app.state().file_upload;
-        upload_route = if let Some(random_route) = app.state().random_route.clone() {
-            format!("/{}/upload", random_route)
+        upload_route = if let Some(path_prefix) = app.state().path_prefix.clone() {
+            format!("/{}/upload", path_prefix)
         } else {
             "/upload".to_string()
         };
@@ -256,7 +254,7 @@ fn configure_app(app: App<MiniserveConfig>) -> App<MiniserveConfig> {
                             req,
                             no_symlinks,
                             file_upload,
-                            random_route.clone(),
+                            path_prefix.clone(),
                             default_color_scheme,
                             u_r.clone(),
                         )
@@ -266,8 +264,8 @@ fn configure_app(app: App<MiniserveConfig>) -> App<MiniserveConfig> {
         }
     };
 
-    let random_route = app.state().random_route.clone().unwrap_or_default();
-    let full_route = format!("/{}", random_route);
+    let path_prefix = app.state().path_prefix.clone().unwrap_or_default();
+    let full_route = format!("/{}", path_prefix);
 
     if let Some(s) = s {
         if app.state().file_upload {
@@ -295,8 +293,8 @@ fn configure_app(app: App<MiniserveConfig>) -> App<MiniserveConfig> {
 fn error_404(req: &HttpRequest<crate::MiniserveConfig>) -> Result<HttpResponse, io::Error> {
     let err_404 = ContextualError::RouteNotFoundError(req.path().to_string());
     let default_color_scheme = req.state().default_color_scheme;
-    let return_address = match &req.state().random_route {
-        Some(random_route) => format!("/{}", random_route),
+    let return_address = match &req.state().path_prefix {
+        Some(path_prefix) => format!("/{}", path_prefix),
         None => "/".to_string(),
     };
 


### PR DESCRIPTION
This PR should replace the `--random-route` argument with both a `--path-prefix` argument and a conflicting `--random-path-prefix` argument.

I use miniserve behind a load-balancer under a specific path, so I need to control the path in miniserves web server, but while I can show the index page in a subdirectory, the links in the file index aren't relative to the current URL.

[Here's an example](https://web.archive.org/web/20191013061658/https://maero.dk/pub) - the indexed file links don't work because it assumes the relative URL path is `/` and it will link to the root domain accordingly (i.e. not under `/pub/`)

The `--random-path-prefix` argument should be a fully functional replacement to `--random-route`. More testing may be required.