### PR TITLE
Compare paths instead of strings

### DIFF
--- a/src/listing.rs
+++ b/src/listing.rs
@@ -152,7 +152,7 @@ pub fn directory_listing<S>(
 
     let base = Path::new(serve_path);
     let random_route = format!("/{}", random_route.unwrap_or_default());
-    let is_root = base.parent().is_none() || req.path() == random_route;
+    let is_root = base.parent().is_none() || Path::new(&req.path()) == Path::new(&random_route);
     let current_dir = match base.strip_prefix(random_route) {
         Ok(c_d) => Path::new("/").join(c_d),
         Err(_) => base.to_path_buf(),


### PR DESCRIPTION
`is_root` was always false when using `--random-route` because of a trailing slash in the result of `req.path()` (so the "Parent directory" link was always visible). Comparing paths instead of strings sounds like a better idea and fixes the problem.