### PR TITLE
Add cargo cache config to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ addons:
       - musl-dev
       - musl-tools
 
+cache: cargo
+
 matrix:
   allow_failures:
     - rust: stable


### PR DESCRIPTION
I would be nice to include `cache: cargo`.

Documentation is in here, https://docs.travis-ci.com/user/languages/rust/#dependency-management