### PR TITLE
Show "now" when last modification time less than 11 seconds

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -913,7 +913,13 @@ fn humanize_systemtime(src_time: Option<SystemTime>) -> Option<String> {
     src_time
         .and_then(|std_time| SystemTime::now().duration_since(std_time).ok())
         .and_then(|from_now| Duration::from_std(from_now).ok())
-        .map(|duration| HumanTime::from(duration).to_text_en(Accuracy::Rough, Tense::Past))
+        .map(|duration| {
+            if duration < Duration::seconds(11) {
+                format!("now")
+            } else {
+                HumanTime::from(duration).to_text_en(Accuracy::Rough, Tense::Past)
+            }
+        })
 }
 
 /// Renders an error on the webpage

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -913,7 +913,7 @@ fn humanize_systemtime(src_time: Option<SystemTime>) -> Option<String> {
     src_time
         .and_then(|std_time| SystemTime::now().duration_since(std_time).ok())
         .and_then(|from_now| Duration::from_std(from_now).ok())
-        .map(|duration| { format!("{}", HumanTime::from(-duration))})
+        .map(|duration| format!("{}", HumanTime::from(-duration)))
 }
 
 /// Renders an error on the webpage

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,6 +1,6 @@
 use actix_web::http::StatusCode;
 use chrono::{DateTime, Duration, Utc};
-use chrono_humanize::{HumanTime};
+use chrono_humanize::HumanTime;
 use maud::{html, Markup, PreEscaped, DOCTYPE};
 use std::time::SystemTime;
 use strum::IntoEnumIterator;

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,6 +1,6 @@
 use actix_web::http::StatusCode;
 use chrono::{DateTime, Duration, Utc};
-use chrono_humanize::{Accuracy, HumanTime, Tense};
+use chrono_humanize::{HumanTime};
 use maud::{html, Markup, PreEscaped, DOCTYPE};
 use std::time::SystemTime;
 use strum::IntoEnumIterator;
@@ -913,13 +913,7 @@ fn humanize_systemtime(src_time: Option<SystemTime>) -> Option<String> {
     src_time
         .and_then(|std_time| SystemTime::now().duration_since(std_time).ok())
         .and_then(|from_now| Duration::from_std(from_now).ok())
-        .map(|duration| {
-            if duration < Duration::seconds(11) {
-                "now".to_string()
-            } else {
-                HumanTime::from(duration).to_text_en(Accuracy::Rough, Tense::Past)
-            }
-        })
+        .map(|duration| { format!("{}", HumanTime::from(-duration))})
 }
 
 /// Renders an error on the webpage

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,6 +1,6 @@
 use actix_web::http::StatusCode;
-use chrono::{DateTime, Duration, Utc};
-use chrono_humanize::HumanTime;
+use chrono::{DateTime, Utc};
+use chrono_humanize::Humanize;
 use maud::{html, Markup, PreEscaped, DOCTYPE};
 use std::time::SystemTime;
 use strum::IntoEnumIterator;
@@ -907,13 +907,9 @@ fn convert_to_utc(src_time: Option<SystemTime>) -> Option<(String, String)> {
 }
 
 /// Converts a SystemTime to a string readable by a human,
-/// i.e. calculates the duration between now() and the given SystemTime,
 /// and gives a rough approximation of the elapsed time since
-fn humanize_systemtime(src_time: Option<SystemTime>) -> Option<String> {
-    src_time
-        .and_then(|std_time| SystemTime::now().duration_since(std_time).ok())
-        .and_then(|from_now| Duration::from_std(from_now).ok())
-        .map(|duration| format!("{}", HumanTime::from(-duration)))
+fn humanize_systemtime(time: Option<SystemTime>) -> Option<String> {
+    time.map(|time| time.humanize())
 }
 
 /// Renders an error on the webpage

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -915,7 +915,7 @@ fn humanize_systemtime(src_time: Option<SystemTime>) -> Option<String> {
         .and_then(|from_now| Duration::from_std(from_now).ok())
         .map(|duration| {
             if duration < Duration::seconds(11) {
-                format!("now")
+                "now".to_string()
             } else {
                 HumanTime::from(duration).to_text_en(Accuracy::Rough, Tense::Past)
             }


### PR DESCRIPTION
Fix Issue #372 Tiny typo "now ago"

According to chrono-humanize `rough` period of accuracy, from 0 to 10 seconds duration, the text "now" is used https://gitlab.com/imp/chrono-humanize-rs/-/blob/master/src/humantime.rs#L173 and then followed by "ago" because of `past` tense https://gitlab.com/imp/chrono-humanize-rs/-/blob/master/src/humantime.rs#L141, which cause the tiny typo "now ago".

After the changes in this PR, if last modification time is less than 11 seconds, only "now" will show up.