### PR TITLE
Remove actix-rt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1648,7 +1648,6 @@ version = "0.9.1-alpha.0"
 dependencies = [
  "actix-files",
  "actix-multipart",
- "actix-rt",
  "actix-web 3.0.2",
  "actix-web-httpauth",
  "alphanumeric-sort",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ zip = "0.5.5"
 qrcodegen = "1.6.0"
 actix-files = "0.3.0"
 actix-multipart = "0.3.0"
-actix-rt = "1.1.1"
 actix-web-httpauth = "0.5.0"
 mime = "0.3"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,7 @@ fn main() {
     }
 }
 
-#[actix_rt::main(miniserve)]
+#[actix_web::main(miniserve)]
 async fn run() -> Result<(), ContextualError> {
     if cfg!(windows) && !Paint::enable_windows_ascii() {
         Paint::disable();


### PR DESCRIPTION
`actix_rt::main` is now re-exported as `actix_web::main`.