### PR TITLE
enable multiple file upload

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -106,7 +106,7 @@ pub fn page(
                                 form id="file_submit" action=(upload_action) method="POST" enctype="multipart/form-data" {
                                     p { "Select a file to upload or drag it anywhere into the window" }
                                     div {
-                                        input#file-input type="file" name="file_to_upload" required="" {}
+                                        input#file-input type="file" name="file_to_upload" required="" multiple {}
                                         button type="submit" { "Upload file" }
                                     }
                                 }


### PR DESCRIPTION
thanks for this nice project! 🚀

this change worked for me, so I am submitting the tiny patch.

tested with miniserve running on Linux (NixOS), with browsers:

- Safari on iPhone
- Firefox on Linux (NixOS)

Firefox was able to select multiple files pre-patch and post-patch. on iPhone, only 1 file was allowed to be selected pre-patch, and multiple were allowed post-patch.