### PR TITLE
Disable Content-Disposition header

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -340,14 +340,14 @@ fn configure_app(app: &mut web::ServiceConfig, conf: &MiniserveConfig) {
             )
         } else {
             let u_r = upload_route.clone();
-            let files;
-            if show_hidden {
-                files = actix_files::Files::new(&full_route, path)
-                    .show_files_listing()
-                    .use_hidden_files();
+            let files = actix_files::Files::new(&full_route, path)
+                .show_files_listing()
+                .disable_content_disposition();
+            let files = if show_hidden {
+                files.use_hidden_files()
             } else {
-                files = actix_files::Files::new(&full_route, path).show_files_listing();
-            }
+                files
+            };
 
             let files = files
                 .files_listing_renderer(move |dir, req| {

--- a/tests/serve_request.rs
+++ b/tests/serve_request.rs
@@ -25,6 +25,11 @@ fn serves_requests_with_no_options(tmpdir: TempDir) -> Result<(), Error> {
     let parsed = Document::from_read(body)?;
     for &file in FILES {
         assert!(parsed.find(|x: &Node| x.text() == file).next().is_some());
+        let resp = reqwest::blocking::get(format!("http://localhost:8080/{}", file))?
+            .error_for_status()?;
+
+        // `content-disposition` header is bogus for symlinks. Disable for now!
+        assert!(resp.headers().get("content-disposition").is_none());
     }
 
     child.kill()?;


### PR DESCRIPTION
Otherwise, symlink files would be served with the filename of the
pointed-to file.

This should fix #462.