### PR TITLE
Resolve symlinks on directory listing

### DIFF
--- a/data/style.scss
+++ b/data/style.scss
@@ -94,7 +94,8 @@ a.symlink:hover {
     color: var(--symlink_link_color);
 }
 
-.symlink-symbol {
+.symlink-symbol::after {
+    content: "⇢";
     display: inline-block;
     border: 1px solid var(--symlink_link_color);
     margin-left: 0.5rem;

--- a/data/style.scss
+++ b/data/style.scss
@@ -88,7 +88,7 @@ a.file:hover {
 .symlink-symbol::after {
     content: "⇢";
     display: inline-block;
-    border: 1px solid var(--symlink_link_color);
+    border: 1px solid;
     margin-left: 0.5rem;
     border-radius: 0.2rem;
     padding: 0 0.1rem;
@@ -521,7 +521,6 @@ th span.active span {
     --text_color: #323232;
     --directory_link_color: #d02474;
     --file_link_color: #0086b3;
-    --symlink_link_color: #ed6a43;
     --table_background: #ffffff;
     --table_text_color: #323232;
     --table_header_background: #323232;
@@ -566,7 +565,6 @@ th span.active span {
     --text_color: #fefefe;
     --directory_link_color: #03a9f4;
     --file_link_color: #ea95ff;
-    --symlink_link_color: #ff9800;
     --table_background: #353946;
     --table_text_color: #eeeeee;
     --table_header_background: #5294e2;
@@ -611,7 +609,6 @@ th span.active span {
     --text_color: #efefef;
     --directory_link_color: #f0dfaf;
     --file_link_color: #87d6d5;
-    --symlink_link_color: #ffccee;
     --table_background: #4a4949;
     --table_text_color: #efefef;
     --table_header_background: #7f9f7f;
@@ -656,7 +653,6 @@ th span.active span {
     --text_color: #f8f8f2;
     --directory_link_color: #f92672;
     --file_link_color: #a6e22e;
-    --symlink_link_color: #fd971f;
     --table_background: #3b3a32;
     --table_text_color: #f8f8f0;
     --table_header_background: #75715e;

--- a/data/style.scss
+++ b/data/style.scss
@@ -77,21 +77,12 @@ a.file:visited,
     color: var(--file_link_color);
 }
 
-a.symlink,
-a.symlink:visited {
-    color: var(--symlink_link_color);
-}
-
 a.directory:hover {
     color: var(--directory_link_color);
 }
 
 a.file:hover {
     color: var(--file_link_color);
-}
-
-a.symlink:hover {
-    color: var(--symlink_link_color);
 }
 
 .symlink-symbol::after {
@@ -484,15 +475,10 @@ th span.active span {
     }
 
     a.root,
-    a.file,
-    a.symlink {
+    a.file {
         display: inline-block;
         flex: 1;
         padding: 0.5625rem 0;
-    }
-
-    a.symlink {
-        width: 100%;
     }
 
     .back {

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -262,7 +262,7 @@ pub fn directory_listing(
 
             // if file is a directory, add '/' to the end of the name
             if let Ok(metadata) = std::fs::metadata(entry.path()) {
-                if skip_symlinks && metadata.file_type().is_symlink() {
+                if skip_symlinks && is_symlink {
                     continue;
                 }
                 let last_modification_date = match metadata.modified() {

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -65,9 +65,6 @@ pub enum EntryType {
 
     /// Entry is a file
     File,
-
-    /// Entry is a symlink
-    Symlink,
 }
 
 /// Entry
@@ -113,11 +110,6 @@ impl Entry {
     /// Returns wether the entry is a file
     pub fn is_file(&self) -> bool {
         self.entry_type == EntryType::File
-    }
-
-    /// Returns wether the entry is a symlink
-    pub fn is_symlink(&self) -> bool {
-        self.entry_type == EntryType::Symlink
     }
 }
 
@@ -260,7 +252,7 @@ pub fn directory_listing(
             let file_name = entry.file_name().to_string_lossy().to_string();
 
             // if file is a directory, add '/' to the end of the name
-            if let Ok(metadata) = entry.metadata() {
+            if let Ok(metadata) = std::fs::metadata(entry.path()) {
                 if skip_symlinks && metadata.file_type().is_symlink() {
                     continue;
                 }
@@ -269,15 +261,7 @@ pub fn directory_listing(
                     Err(_) => None,
                 };
 
-                if metadata.file_type().is_symlink() {
-                    entries.push(Entry::new(
-                        file_name,
-                        EntryType::Symlink,
-                        file_url,
-                        None,
-                        last_modification_date,
-                    ));
-                } else if metadata.is_dir() {
+                if metadata.is_dir() {
                     entries.push(Entry::new(
                         file_name,
                         EntryType::Directory,
@@ -285,7 +269,7 @@ pub fn directory_listing(
                         None,
                         last_modification_date,
                     ));
-                } else {
+                } else if metadata.is_file() {
                     entries.push(Entry::new(
                         file_name,
                         EntryType::File,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -341,10 +341,6 @@ fn entry_row(
                                 }
                             }
                         }
-                    } @else if entry.is_symlink() {
-                        a.symlink href=(parametrized_link(&entry.link, sort_method, sort_order)) {
-                           (entry.name)  span.symlink-symbol { "⇢" }
-                        }
                     }
                 }
             }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -329,11 +329,17 @@ fn entry_row(
                     @if entry.is_dir() {
                         a.directory href=(parametrized_link(&entry.link, sort_method, sort_order)) {
                             (entry.name) "/"
+                            @if entry.is_symlink {
+                                span.symlink-symbol { "⇢" }
+                            }
                         }
                     } @else if entry.is_file() {
                         div.file-entry {
                             a.file href=(&entry.link) {
                                 (entry.name)
+                                @if entry.is_symlink {
+                                    span.symlink-symbol { "⇢" }
+                                }
                             }
                             @if let Some(size) = entry.size {
                                 span.mobile-info.size {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -330,7 +330,7 @@ fn entry_row(
                         a.directory href=(parametrized_link(&entry.link, sort_method, sort_order)) {
                             (entry.name) "/"
                             @if entry.is_symlink {
-                                span.symlink-symbol { "⇢" }
+                                span.symlink-symbol { }
                             }
                         }
                     } @else if entry.is_file() {
@@ -338,7 +338,7 @@ fn entry_row(
                             a.file href=(&entry.link) {
                                 (entry.name)
                                 @if entry.is_symlink {
-                                    span.symlink-symbol { "⇢" }
+                                    span.symlink-symbol { }
                                 }
                             }
                             @if let Some(size) = entry.size {


### PR DESCRIPTION
This has the benefit of showing the size and modification date of the pointed-to file. Symlink to directories now respects '--dirs-first' option and broken symlinks don't show up in directory listing.

The only downside AFAIK is more syscalls when listing directories.

@svenstaro Any input on this? should it be configurable? can we abandon the symlink symbol?