### PR TITLE
Fix QR code display when using --random-route

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -192,7 +192,7 @@ fn color_scheme_selector(show_qrcode: bool) -> Markup {
         nav {
             @if show_qrcode {
                 div {
-                    p onmouseover="document.querySelector('#qrcode').src = `/?qrcode=${encodeURIComponent(window.location.href)}`" {
+                    p onmouseover="document.querySelector('#qrcode').src = `?qrcode=${encodeURIComponent(window.location.href)}`" {
                         "QR code"
                     }
                     div.qrcode {


### PR DESCRIPTION
Previously the QR code would not display because `/` is a 404 when using `--random-route`.