### PR TITLE
Fix CI on Rust nightly by bumping standback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2580,9 +2580,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "standback"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "decebb311175fdaf1bf8a14583716e93163c566db2ead1c1d608c3e1e4313cb8"
+checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
 dependencies = [
  "version_check 0.9.3",
 ]


### PR DESCRIPTION
Previously building would fail with:

```
error[E0432]: unresolved import `core::task::Wake`
Error:    --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/standback-0.2.16/src/lib.rs:520:13
    |
520 |     pub use core::task::Wake;
    |             ^^^^^^^^^^^^----
    |             |           |
    |             |           help: a similar name exists in the module (notice the capitalization): `wake`
    |             no `Wake` in `task`

error: aborting due to previous error
Error: aborting due to previous error
For more information about this error, try `rustc --explain E0432`.
error: could not compile `standback`
Error: could not compile `standback`
```

https://github.com/jhpratt/standback/releases/tag/v0.2.17
