### PR TITLE
Generate completions with `miniserve --print-completions <shell>`

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -21,7 +21,7 @@ const ROUTE_ALPHABET: [char; 16] = [
     about,
     global_settings = &[structopt::clap::AppSettings::ColoredHelp],
 )]
-struct CliArgs {
+pub struct CliArgs {
     /// Be verbose, includes emitting access logs
     #[structopt(short = "v", long = "verbose")]
     verbose: bool,
@@ -131,6 +131,10 @@ struct CliArgs {
     /// Hide version footer
     #[structopt(short = "F", long = "hide-version-footer")]
     hide_version_footer: bool,
+
+    /// Generate completion file for a shell
+    #[structopt(long = "print-completions", value_name = "shell")]
+    pub print_completions: Option<structopt::clap::Shell>,
 }
 
 /// Checks wether an interface is valid, i.e. it can be parsed into an IP address
@@ -205,9 +209,7 @@ pub fn parse_header(src: &str) -> Result<HeaderMap, httparse::Error> {
 }
 
 /// Parses the command line arguments
-pub fn parse_args() -> crate::MiniserveConfig {
-    let args = CliArgs::from_args();
-
+pub fn parse_args(args: CliArgs) -> crate::MiniserveConfig {
     let interfaces = if !args.interfaces.is_empty() {
         args.interfaces
     } else {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3,7 +3,7 @@ mod fixtures;
 use assert_cmd::prelude::*;
 use fixtures::Error;
 use std::process::Command;
-use structopt::clap::{crate_name, crate_version};
+use structopt::clap::{crate_name, crate_version, Shell};
 
 #[test]
 /// Show help and exit.
@@ -24,6 +24,32 @@ fn version_shows() -> Result<(), Error> {
         .assert()
         .success()
         .stdout(format!("{} {}\n", crate_name!(), crate_version!()));
+
+    Ok(())
+}
+
+#[test]
+/// Print completions and exit.
+fn print_completions() -> Result<(), Error> {
+    for shell in &Shell::variants() {
+        Command::cargo_bin("miniserve")?
+            .arg("--print-completions")
+            .arg(&shell)
+            .assert()
+            .success();
+    }
+
+    Ok(())
+}
+
+#[test]
+/// Print completions rejects invalid shells.
+fn print_completions_invalid_shell() -> Result<(), Error> {
+    Command::cargo_bin("miniserve")?
+        .arg("--print-completions")
+        .arg("fakeshell")
+        .assert()
+        .failure();
 
     Ok(())
 }


### PR DESCRIPTION
This patch adds a ~`completions` subcommand~ `--print-completions` option to generate shell completion files at runtime. This ensures the completions are always up to date.

Fixes #377.

CI should pass once #481 is merged. This is some of my first Rust code so lmk if I'm doing anything weird...