### PR TITLE
Wrap breadcrumbs at any char

### DIFF
--- a/data/style.scss
+++ b/data/style.scss
@@ -39,7 +39,7 @@ body {
 }
 
 .title {
-    word-break: break-word;
+    word-break: break-all;
 }
 
 .title a {


### PR DESCRIPTION
This would make a good use of space in mobile view.

* Before
![image](https://user-images.githubusercontent.com/28497461/114188790-2ad67d80-9952-11eb-926d-088bde973c62.png)
* After
        <img height=90 src="https://user-images.githubusercontent.com/28497461/115133177-e2345980-a00e-11eb-8ff0-e9913e825bed.png"/>

