### PR TITLE
tests: Refactor!

### DIFF
--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -1,30 +1,15 @@
 ﻿mod fixtures;
 
-use assert_cmd::prelude::*;
-use assert_fs::fixture::TempDir;
-use fixtures::{port, tmpdir, Error};
+use fixtures::{server, Error, TestServer};
 use reqwest::StatusCode;
 use rstest::rstest;
 use select::document::Document;
 use select::predicate::Text;
-use std::process::{Command, Stdio};
-use std::thread::sleep;
-use std::time::Duration;
 
 #[rstest]
-fn archives_are_disabled(tmpdir: TempDir, port: u16) -> Result<(), Error> {
-    let mut child = Command::cargo_bin("miniserve")?
-        .arg(tmpdir.path())
-        .arg("-p")
-        .arg(port.to_string())
-        .stdout(Stdio::null())
-        .spawn()?;
-
-    sleep(Duration::from_secs(1));
-
+fn archives_are_disabled(server: TestServer) -> Result<(), Error> {
     // Ensure the links to the archives are not present
-    let body = reqwest::blocking::get(format!("http://localhost:{}", port).as_str())?
-        .error_for_status()?;
+    let body = reqwest::blocking::get(server.url())?.error_for_status()?;
     let parsed = Document::from_read(body)?;
     assert!(parsed
         .find(Text)
@@ -32,63 +17,42 @@ fn archives_are_disabled(tmpdir: TempDir, port: u16) -> Result<(), Error> {
 
     // Try to download anyway, ensure it's forbidden
     assert_eq!(
-        reqwest::blocking::get(format!("http://localhost:{}/?download=tar_gz", port).as_str())?
-            .status(),
+        reqwest::blocking::get(server.url().join("?download=tar_gz")?)?.status(),
         StatusCode::FORBIDDEN
     );
     assert_eq!(
-        reqwest::blocking::get(format!("http://localhost:{}/?download=tar", port).as_str())?
-            .status(),
+        reqwest::blocking::get(server.url().join("?download=tar")?)?.status(),
         StatusCode::FORBIDDEN
     );
     assert_eq!(
-        reqwest::blocking::get(format!("http://localhost:{}/?download=zip", port).as_str())?
-            .status(),
+        reqwest::blocking::get(server.url().join("?download=zip")?)?.status(),
         StatusCode::FORBIDDEN
     );
-
-    child.kill()?;
 
     Ok(())
 }
 
-#[rstest]
-fn test_tar_archives(tmpdir: TempDir, port: u16) -> Result<(), Error> {
-    let mut child = Command::cargo_bin("miniserve")?
-        .arg(tmpdir.path())
-        .arg("-p")
-        .arg(port.to_string())
-        .arg("-g")
-        .stdout(Stdio::null())
-        .spawn()?;
-
-    sleep(Duration::from_secs(1));
-
+#[rstest(server(&["-g"]))]
+fn test_tar_archives(server: TestServer) -> Result<(), Error> {
     // Ensure the links to the tar archive exists and tar not exists
-    let body = reqwest::blocking::get(format!("http://localhost:{}", port).as_str())?
-        .error_for_status()?;
+    let body = reqwest::blocking::get(server.url())?.error_for_status()?;
     let parsed = Document::from_read(body)?;
     assert!(parsed.find(Text).any(|x| x.text() == "Download .tar.gz"));
     assert!(parsed.find(Text).all(|x| x.text() != "Download .tar"));
 
     // Try to download, only tar_gz should works
     assert_eq!(
-        reqwest::blocking::get(format!("http://localhost:{}/?download=tar_gz", port).as_str())?
-            .status(),
+        reqwest::blocking::get(server.url().join("?download=tar_gz")?)?.status(),
         StatusCode::OK
     );
     assert_eq!(
-        reqwest::blocking::get(format!("http://localhost:{}/?download=tar", port).as_str())?
-            .status(),
+        reqwest::blocking::get(server.url().join("?download=tar")?)?.status(),
         StatusCode::FORBIDDEN
     );
     assert_eq!(
-        reqwest::blocking::get(format!("http://localhost:{}/?download=zip", port).as_str())?
-            .status(),
+        reqwest::blocking::get(server.url().join("?download=zip")?)?.status(),
         StatusCode::FORBIDDEN
     );
-
-    child.kill()?;
 
     Ok(())
 }

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -1,7 +1,12 @@
+use assert_cmd::prelude::*;
 use assert_fs::fixture::TempDir;
 use assert_fs::prelude::*;
 use port_check::free_local_port;
+use reqwest::Url;
 use rstest::fixture;
+use std::process::{Child, Command, Stdio};
+use std::thread::sleep;
+use std::time::Duration;
 
 /// Error type used by tests
 pub type Error = Box<dyn std::error::Error>;
@@ -75,4 +80,86 @@ pub fn tmpdir() -> TempDir {
 #[allow(dead_code)]
 pub fn port() -> u16 {
     free_local_port().expect("Couldn't find a free local port")
+}
+
+/// Run miniserve as a server; Start with a temporary directory, a free port and some
+/// optional arguments then wait for a while for the server setup to complete.
+#[fixture(args=&[] as &[&str])]
+#[allow(dead_code)]
+pub fn server<S>(args: impl IntoIterator<Item = S>) -> TestServer
+where
+    S: AsRef<std::ffi::OsStr>,
+{
+    let port = port();
+    let tmpdir = tmpdir();
+    let child = Command::cargo_bin("miniserve")
+        .expect("Couldn't find test binary")
+        .arg(tmpdir.path())
+        .arg("-p")
+        .arg(port.to_string())
+        .args(args)
+        .stdout(Stdio::null())
+        .spawn()
+        .expect("Couldn't run test binary");
+
+    sleep(Duration::from_secs(1));
+    TestServer::new(port, tmpdir, child)
+}
+
+/// Same as `server()` but ignore stderr
+#[fixture(args=&[] as &[&str])]
+#[allow(dead_code)]
+pub fn server_no_stderr<S>(args: impl IntoIterator<Item = S>) -> TestServer
+where
+    S: AsRef<std::ffi::OsStr>,
+{
+    let port = port();
+    let tmpdir = tmpdir();
+    let child = Command::cargo_bin("miniserve")
+        .expect("Couldn't find test binary")
+        .arg(tmpdir.path())
+        .arg("-p")
+        .arg(port.to_string())
+        .args(args)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("Couldn't run test binary");
+
+    sleep(Duration::from_secs(1));
+    TestServer::new(port, tmpdir, child)
+}
+
+#[allow(dead_code)]
+pub struct TestServer {
+    port: u16,
+    tmpdir: TempDir,
+    child: Child,
+}
+
+#[allow(dead_code)]
+impl TestServer {
+    pub fn new(port: u16, tmpdir: TempDir, child: Child) -> Self {
+        Self {
+            port,
+            tmpdir,
+            child,
+        }
+    }
+    pub fn url(&self) -> Url {
+        Url::parse(&format!("http://localhost:{}", self.port)).unwrap()
+    }
+    pub fn path(&self) -> &std::path::Path {
+        self.tmpdir.path()
+    }
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        self.child.kill().expect("Couldn't kill test server");
+        /* TODO may need .wait() ? */
+    }
 }

--- a/tests/header.rs
+++ b/tests/header.rs
@@ -1,29 +1,15 @@
 mod fixtures;
 
-use assert_cmd::prelude::*;
-use assert_fs::fixture::TempDir;
-use fixtures::{port, tmpdir, Error};
+use fixtures::{server, Error};
 use rstest::rstest;
-use std::process::{Command, Stdio};
-use std::thread::sleep;
-use std::time::Duration;
 
 #[rstest(headers,
     case(vec!["x-info: 123".to_string()]),
     case(vec!["x-info1: 123".to_string(), "x-info2: 345".to_string()])
 )]
-fn custom_header_set(tmpdir: TempDir, port: u16, headers: Vec<String>) -> Result<(), Error> {
-    let mut child = Command::cargo_bin("miniserve")?
-        .arg(tmpdir.path())
-        .arg("-p")
-        .arg(port.to_string())
-        .args(headers.iter().flat_map(|h| vec!["--header", h]))
-        .stdout(Stdio::null())
-        .spawn()?;
-
-    sleep(Duration::from_secs(1));
-
-    let resp = reqwest::blocking::get(format!("http://localhost:{}", port).as_str())?;
+fn custom_header_set(headers: Vec<String>) -> Result<(), Error> {
+    let server = server(headers.iter().flat_map(|h| vec!["--header", h]));
+    let resp = reqwest::blocking::get(server.url())?;
 
     for header in headers {
         let mut header_split = header.splitn(2, ':');
@@ -31,8 +17,6 @@ fn custom_header_set(tmpdir: TempDir, port: u16, headers: Vec<String>) -> Result
         let header_value = header_split.next().unwrap().trim();
         assert_eq!(resp.headers().get(header_name).unwrap(), header_value);
     }
-
-    child.kill()?;
 
     Ok(())
 }

--- a/tests/navigation.rs
+++ b/tests/navigation.rs
@@ -1,16 +1,11 @@
 mod fixtures;
 mod utils;
 
-use assert_cmd::prelude::*;
-use assert_fs::fixture::TempDir;
-use fixtures::{port, tmpdir, Error, DEEPLY_NESTED_FILE, DIRECTORIES};
+use fixtures::{server, Error, TestServer, DEEPLY_NESTED_FILE, DIRECTORIES};
 use pretty_assertions::{assert_eq, assert_ne};
 use rstest::rstest;
 use select::document::Document;
 use std::process::{Command, Stdio};
-use std::thread::sleep;
-use std::time::Duration;
-use url::Url;
 use utils::get_link_from_text;
 
 #[rstest(
@@ -22,45 +17,19 @@ use utils::get_link_from_text;
     case("/very/deeply/nested", "/very/deeply/nested/")
 )]
 /// Directories get a trailing slash.
-fn index_gets_trailing_slash(
-    tmpdir: TempDir,
-    port: u16,
-    input: &str,
-    expected: &str,
-) -> Result<(), Error> {
-    let mut child = Command::cargo_bin("miniserve")?
-        .arg("-p")
-        .arg(port.to_string())
-        .arg(tmpdir.path())
-        .stdout(Stdio::null())
-        .spawn()?;
-
-    sleep(Duration::from_secs(1));
-
-    let base_url = Url::parse(&format!("http://localhost:{}", port))?;
-    let resp = reqwest::blocking::get(base_url.join(input)?)?;
+fn index_gets_trailing_slash(server: TestServer, input: &str, expected: &str) -> Result<(), Error> {
+    let resp = reqwest::blocking::get(server.url().join(input)?)?;
     assert!(resp.url().as_str().ends_with(expected));
-
-    child.kill()?;
 
     Ok(())
 }
 
 #[rstest]
 /// Can't navigate up the root.
-fn cant_navigate_up_the_root(tmpdir: TempDir, port: u16) -> Result<(), Error> {
-    let mut child = Command::cargo_bin("miniserve")?
-        .arg("-p")
-        .arg(port.to_string())
-        .arg(tmpdir.path())
-        .stdout(Stdio::null())
-        .spawn()?;
-
-    sleep(Duration::from_secs(1));
-
+fn cant_navigate_up_the_root(server: TestServer) -> Result<(), Error> {
     // We're using curl for this as it has the option `--path-as-is` which doesn't normalize
     // invalid urls. A useful feature in this particular case.
-    let base_url = Url::parse(&format!("http://localhost:{}", port))?;
+    let base_url = server.url();
     let curl_successful = Command::new("curl")
         .arg("-s")
         .arg("--fail")
@@ -71,24 +40,13 @@ fn cant_navigate_up_the_root(tmpdir: TempDir, port: u16) -> Result<(), Error> {
         .success();
     assert!(curl_successful);
 
-    child.kill()?;
-
     Ok(())
 }
 
 #[rstest]
 /// We can navigate into directories and back using shown links.
-fn can_navigate_into_dirs_and_back(tmpdir: TempDir, port: u16) -> Result<(), Error> {
-    let mut child = Command::cargo_bin("miniserve")?
-        .arg("-p")
-        .arg(port.to_string())
-        .arg(tmpdir.path())
-        .stdout(Stdio::null())
-        .spawn()?;
-
-    sleep(Duration::from_secs(1));
-
-    let base_url = Url::parse(&format!("http://localhost:{}/", port))?;
+fn can_navigate_into_dirs_and_back(server: TestServer) -> Result<(), Error> {
+    let base_url = server.url();
     let initial_body = reqwest::blocking::get(base_url.as_str())?.error_for_status()?;
     let initial_parsed = Document::from_read(initial_body)?;
     for &directory in DIRECTORIES {
@@ -105,23 +63,12 @@ fn can_navigate_into_dirs_and_back(tmpdir: TempDir, port: u16) -> Result<(), Err
         assert_eq!(resp.url().as_str(), base_url.as_str());
     }
 
-    child.kill()?;
-
     Ok(())
 }
 
 #[rstest]
 /// We can navigate deep into the file tree and back using shown links.
-fn can_navigate_deep_into_dirs_and_back(tmpdir: TempDir, port: u16) -> Result<(), Error> {
-    let mut child = Command::cargo_bin("miniserve")?
-        .arg("-p")
-        .arg(port.to_string())
-        .arg(tmpdir.path())
-        .stdout(Stdio::null())
-        .spawn()?;
-
-    sleep(Duration::from_secs(1));
-
+fn can_navigate_deep_into_dirs_and_back(server: TestServer) -> Result<(), Error> {
     // Create a vector of directory names. We don't need to fetch the file and so we'll
     // remove that part.
     let dir_names = {
@@ -132,7 +79,7 @@ fn can_navigate_deep_into_dirs_and_back(tmpdir: TempDir, port: u16) -> Result<()
         comps.pop();
         comps
     };
-    let base_url = Url::parse(&format!("http://localhost:{}/", port))?;
+    let base_url = server.url();
 
     // First we'll go forwards through the directory tree and then we'll go backwards.
     // In the end, we'll have to end up where we came from.
@@ -157,29 +104,17 @@ fn can_navigate_deep_into_dirs_and_back(tmpdir: TempDir, port: u16) -> Result<()
     }
     assert_eq!(base_url, next_url);
 
-    child.kill()?;
-
     Ok(())
 }
 
 #[rstest(use_custom_title, case(true), case(false))]
 /// We can use breadcrumbs to navigate.
-fn can_navigate_using_breadcrumbs(
-    tmpdir: TempDir,
-    port: u16,
-    use_custom_title: bool,
-) -> Result<(), Error> {
-    let mut command_base = Command::cargo_bin("miniserve")?;
-    let mut command = command_base.arg("-p").arg(port.to_string());
-
-    if use_custom_title {
-        command = command.arg("--title").arg("some title")
-    }
-
-    let mut child = command.arg(tmpdir.path()).stdout(Stdio::null()).spawn()?;
-
-    sleep(Duration::from_secs(1));
-
+fn can_navigate_using_breadcrumbs(use_custom_title: bool) -> Result<(), Error> {
+    let server = server(if use_custom_title {
+        &["--title", "some title"]
+    } else {
+        &[] as &[&str]
+    });
     // Create a vector of directory names. We don't need to fetch the file and so we'll
     // remove that part.
     let dir: String = {
@@ -191,7 +126,7 @@ fn can_navigate_using_breadcrumbs(
         comps.join("")
     };
 
-    let base_url = Url::parse(&format!("http://localhost:{}/", port))?;
+    let base_url = server.url();
     let nested_url = base_url.join(&dir)?;
 
     let resp = reqwest::blocking::get(nested_url.as_str())?;
@@ -201,7 +136,7 @@ fn can_navigate_using_breadcrumbs(
     let title_name = if use_custom_title {
         "some title".to_string()
     } else {
-        format!("localhost:{}", port)
+        format!("localhost:{}", server.port())
     };
 
     // can go back to root dir by clicking title
@@ -216,8 +151,6 @@ fn can_navigate_using_breadcrumbs(
     // current dir is not linked
     let current_dir_link = get_link_from_text(&parsed, "nested");
     assert_eq!(None, current_dir_link);
-
-    child.kill()?;
 
     Ok(())
 }

--- a/tests/qrcode.rs
+++ b/tests/qrcode.rs
@@ -1,74 +1,35 @@
 mod fixtures;
 
-use assert_cmd::prelude::*;
-use assert_fs::fixture::TempDir;
-use fixtures::{port, tmpdir, Error};
+use fixtures::{server, server_no_stderr, Error, TestServer};
 use reqwest::StatusCode;
 use rstest::rstest;
 use select::document::Document;
 use select::predicate::Attr;
 use std::iter::repeat_with;
-use std::process::{Command, Stdio};
-use std::thread::sleep;
-use std::time::Duration;
 
 #[rstest]
-fn hide_qrcode_element(tmpdir: TempDir, port: u16) -> Result<(), Error> {
-    let mut child = Command::cargo_bin("miniserve")?
-        .arg(tmpdir.path())
-        .arg("-p")
-        .arg(port.to_string())
-        .stdout(Stdio::null())
-        .spawn()?;
-
-    sleep(Duration::from_secs(1));
-
-    let body = reqwest::blocking::get(format!("http://localhost:{}", port).as_str())?
-        .error_for_status()?;
+fn hide_qrcode_element(server: TestServer) -> Result<(), Error> {
+    let body = reqwest::blocking::get(server.url())?.error_for_status()?;
     let parsed = Document::from_read(body)?;
     assert!(parsed.find(Attr("id", "qrcode")).next().is_none());
 
-    child.kill()?;
-
     Ok(())
 }
 
-#[rstest]
-fn show_qrcode_element(tmpdir: TempDir, port: u16) -> Result<(), Error> {
-    let mut child = Command::cargo_bin("miniserve")?
-        .arg(tmpdir.path())
-        .arg("-p")
-        .arg(port.to_string())
-        .arg("-q")
-        .stdout(Stdio::null())
-        .spawn()?;
-
-    sleep(Duration::from_secs(1));
-
-    let body = reqwest::blocking::get(format!("http://localhost:{}", port).as_str())?
-        .error_for_status()?;
+#[rstest(server(&["-q"]))]
+fn show_qrcode_element(server: TestServer) -> Result<(), Error> {
+    let body = reqwest::blocking::get(server.url())?.error_for_status()?;
     let parsed = Document::from_read(body)?;
     assert!(parsed.find(Attr("id", "qrcode")).next().is_some());
 
-    child.kill()?;
-
     Ok(())
 }
 
 #[rstest]
-fn get_svg_qrcode(tmpdir: TempDir, port: u16) -> Result<(), Error> {
-    let mut child = Command::cargo_bin("miniserve")?
-        .arg(tmpdir.path())
-        .arg("-p")
-        .arg(port.to_string())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()?;
-
-    sleep(Duration::from_secs(1));
-
+fn get_svg_qrcode(server_no_stderr: TestServer) -> Result<(), Error> {
+    let server = server_no_stderr;
     // Ok
-    let resp = reqwest::blocking::get(format!("http://localhost:{}/?qrcode=test", port).as_str())?;
+    let resp = reqwest::blocking::get(server.url().join("/?qrcode=test")?)?;
 
     assert_eq!(resp.status(), StatusCode::OK);
     assert_eq!(resp.headers()["Content-Type"], "image/svg+xml");
@@ -78,12 +39,9 @@ fn get_svg_qrcode(tmpdir: TempDir, port: u16) -> Result<(), Error> {
 
     // Err
     let content: String = repeat_with(|| '0').take(8 * 1024).collect();
-    let resp =
-        reqwest::blocking::get(format!("http://localhost:{}/?qrcode={}", port, content).as_str())?;
+    let resp = reqwest::blocking::get(server.url().join(&format!("?qrcode={}", content))?)?;
 
     assert_eq!(resp.status(), StatusCode::URI_TOO_LONG);
-
-    child.kill()?;
 
     Ok(())
 }

--- a/tests/serve_request.rs
+++ b/tests/serve_request.rs
@@ -2,13 +2,14 @@ mod fixtures;
 
 use assert_cmd::prelude::*;
 use assert_fs::fixture::TempDir;
-use fixtures::{port, tmpdir, Error, DIRECTORIES, FILES, HIDDEN_DIRECTORIES, HIDDEN_FILES};
+use fixtures::{
+    port, server, tmpdir, Error, TestServer, DIRECTORIES, FILES, HIDDEN_DIRECTORIES, HIDDEN_FILES,
+};
 use http::StatusCode;
 use regex::Regex;
 use rstest::rstest;
 use select::document::Document;
 use select::node::Node;
-use std::path::Path;
 use std::process::{Command, Stdio};
 use std::thread::sleep;
 use std::time::Duration;
@@ -39,28 +40,13 @@ fn serves_requests_with_no_options(tmpdir: TempDir) -> Result<(), Error> {
 }
 
 #[rstest]
-fn serves_requests_with_non_default_port(tmpdir: TempDir, port: u16) -> Result<(), Error> {
-    let mut child = Command::cargo_bin("miniserve")?
-        .arg(tmpdir.path())
-        .arg("-p")
-        .arg(port.to_string())
-        .stdout(Stdio::null())
-        .spawn()?;
-
-    sleep(Duration::from_secs(1));
-
-    let body = reqwest::blocking::get(format!("http://localhost:{}", port).as_str())?
-        .error_for_status()?;
+fn serves_requests_with_non_default_port(server: TestServer) -> Result<(), Error> {
+    let body = reqwest::blocking::get(server.url())?.error_for_status()?;
     let parsed = Document::from_read(body)?;
 
     for &file in FILES {
         let f = parsed.find(|x: &Node| x.text() == file).next().unwrap();
-        reqwest::blocking::get(format!(
-            "http://localhost:{}/{}",
-            port,
-            f.attr("href").unwrap()
-        ))?
-        .error_for_status()?;
+        reqwest::blocking::get(server.url().join(f.attr("href").unwrap())?)?.error_for_status()?;
         assert_eq!(
             format!("/{}", file),
             percent_encoding::percent_decode_str(f.attr("href").unwrap()).decode_utf8_lossy(),
@@ -73,8 +59,7 @@ fn serves_requests_with_non_default_port(tmpdir: TempDir, port: u16) -> Result<(
             .next()
             .is_some());
         let dir_body =
-            reqwest::blocking::get(format!("http://localhost:{}/{}", port, directory).as_str())?
-                .error_for_status()?;
+            reqwest::blocking::get(server.url().join(&directory)?)?.error_for_status()?;
         let dir_body_parsed = Document::from_read(dir_body)?;
         for &file in FILES {
             assert!(dir_body_parsed
@@ -84,25 +69,12 @@ fn serves_requests_with_non_default_port(tmpdir: TempDir, port: u16) -> Result<(
         }
     }
 
-    child.kill()?;
-
     Ok(())
 }
 
-#[rstest]
-fn serves_requests_hidden_files(tmpdir: TempDir, port: u16) -> Result<(), Error> {
-    let mut child = Command::cargo_bin("miniserve")?
-        .arg(tmpdir.path())
-        .arg("-p")
-        .arg(port.to_string())
-        .arg("--hidden")
-        .stdout(Stdio::null())
-        .spawn()?;
-
-    sleep(Duration::from_secs(1));
-
-    let body = reqwest::blocking::get(format!("http://localhost:{}", port).as_str())?
-        .error_for_status()?;
+#[rstest(server(&["--hidden"]))]
+fn serves_requests_hidden_files(server: TestServer) -> Result<(), Error> {
+    let body = reqwest::blocking::get(server.url())?.error_for_status()?;
     let parsed = Document::from_read(body)?;
 
     for &file in FILES.into_iter().chain(HIDDEN_FILES) {
@@ -119,8 +91,7 @@ fn serves_requests_hidden_files(tmpdir: TempDir, port: u16) -> Result<(), Error>
             .next()
             .is_some());
         let dir_body =
-            reqwest::blocking::get(format!("http://localhost:{}/{}", port, directory).as_str())?
-                .error_for_status()?;
+            reqwest::blocking::get(server.url().join(&directory)?)?.error_for_status()?;
         let dir_body_parsed = Document::from_read(dir_body)?;
         for &file in FILES.into_iter().chain(HIDDEN_FILES) {
             assert!(dir_body_parsed
@@ -130,24 +101,12 @@ fn serves_requests_hidden_files(tmpdir: TempDir, port: u16) -> Result<(), Error>
         }
     }
 
-    child.kill()?;
-
     Ok(())
 }
 
 #[rstest]
-fn serves_requests_no_hidden_files_without_flag(tmpdir: TempDir, port: u16) -> Result<(), Error> {
-    let mut child = Command::cargo_bin("miniserve")?
-        .arg(tmpdir.path())
-        .arg("-p")
-        .arg(port.to_string())
-        .stdout(Stdio::null())
-        .spawn()?;
-
-    sleep(Duration::from_secs(1));
-
-    let body = reqwest::blocking::get(format!("http://localhost:{}", port).as_str())?
-        .error_for_status()?;
+fn serves_requests_no_hidden_files_without_flag(server: TestServer) -> Result<(), Error> {
+    let body = reqwest::blocking::get(server.url())?.error_for_status()?;
     let parsed = Document::from_read(body)?;
 
     for &hidden_item in HIDDEN_FILES.into_iter().chain(HIDDEN_DIRECTORIES) {
@@ -155,54 +114,34 @@ fn serves_requests_no_hidden_files_without_flag(tmpdir: TempDir, port: u16) -> R
             .find(|x: &Node| x.text() == hidden_item)
             .next()
             .is_none());
-        let resp =
-            reqwest::blocking::get(format!("http://localhost:{}/{}", port, hidden_item).as_str())?;
+        let resp = reqwest::blocking::get(server.url().join(&hidden_item)?)?;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
-
-    child.kill()?;
 
     Ok(())
 }
 
 #[rstest(no_symlinks, case(true), case(false))]
-fn serves_requests_symlinks(tmpdir: TempDir, port: u16, no_symlinks: bool) -> Result<(), Error> {
-    let mut comm = Command::cargo_bin("miniserve")?;
-    comm.arg(tmpdir.path())
-        .arg("-p")
-        .arg(port.to_string())
-        .stdout(Stdio::null());
-    if no_symlinks {
-        comm.arg("--no-symlinks");
-    }
-
-    let mut child = comm.spawn()?;
-    sleep(Duration::from_secs(1));
-
+fn serves_requests_symlinks(no_symlinks: bool) -> Result<(), Error> {
+    let server = server(["--no-symlinks"].iter().filter(|_| no_symlinks));
     let files = &["symlink-file.html"];
     let dirs = &["symlink-dir/"];
     let broken = &["symlink broken"];
 
     for &directory in dirs {
-        let orig = Path::new(DIRECTORIES[0].strip_suffix("/").unwrap());
-        let link = tmpdir
-            .path()
-            .join(Path::new(directory.strip_suffix("/").unwrap()));
+        let orig = DIRECTORIES[0].strip_suffix("/").unwrap();
+        let link = server.path().join(directory.strip_suffix("/").unwrap());
         symlink_dir(orig, link).expect("Couldn't create symlink");
     }
     for &file in files {
-        let orig = Path::new(FILES[0]);
-        let link = tmpdir.path().join(Path::new(file));
-        symlink_file(orig, link).expect("Couldn't create symlink");
+        symlink_file(FILES[0], server.path().join(file)).expect("Couldn't create symlink");
     }
     for &file in broken {
-        let orig = Path::new("should-not-exist.xxx");
-        let link = tmpdir.path().join(Path::new(file));
-        symlink_file(orig, link).expect("Couldn't create symlink");
+        symlink_file("souldnt-exist.xxx", server.path().join(file))
+            .expect("Couldn't create symlink");
     }
 
-    let body = reqwest::blocking::get(format!("http://localhost:{}", port).as_str())?
-        .error_for_status()?;
+    let body = reqwest::blocking::get(server.url())?.error_for_status()?;
     let parsed = Document::from_read(body)?;
 
     for &entry in files.into_iter().chain(dirs) {
@@ -216,8 +155,7 @@ fn serves_requests_symlinks(tmpdir: TempDir, port: u16, no_symlinks: bool) -> Re
 
         let node = node.unwrap();
         assert_eq!(node.attr("href").unwrap().strip_prefix("/").unwrap(), entry);
-        reqwest::blocking::get(format!("http://localhost:{}/{}", port, entry))?
-            .error_for_status()?;
+        reqwest::blocking::get(server.url().join(&entry)?)?.error_for_status()?;
         if entry.ends_with("/") {
             assert_eq!(node.attr("class").unwrap(), "directory");
         } else {
@@ -227,8 +165,6 @@ fn serves_requests_symlinks(tmpdir: TempDir, port: u16, no_symlinks: bool) -> Re
     for &entry in broken {
         assert!(parsed.find(|x: &Node| x.text() == entry).next().is_none());
     }
-
-    child.kill()?;
 
     Ok(())
 }

--- a/tests/upload_files.rs
+++ b/tests/upload_files.rs
@@ -1,33 +1,17 @@
 mod fixtures;
 
-use assert_cmd::prelude::*;
-use assert_fs::fixture::TempDir;
-use fixtures::{port, tmpdir, Error};
+use fixtures::{server, Error, TestServer};
 use reqwest::blocking::{multipart, Client};
 use rstest::rstest;
 use select::document::Document;
 use select::predicate::{Attr, Text};
-use std::process::{Command, Stdio};
-use std::thread::sleep;
-use std::time::Duration;
 
-#[rstest]
-fn uploading_files_works(tmpdir: TempDir, port: u16) -> Result<(), Error> {
+#[rstest(server(&["-u"]))]
+fn uploading_files_works(server: TestServer) -> Result<(), Error> {
     let test_file_name = "uploaded test file.txt";
 
-    let mut child = Command::cargo_bin("miniserve")?
-        .arg(tmpdir.path())
-        .arg("-p")
-        .arg(port.to_string())
-        .arg("-u")
-        .stdout(Stdio::null())
-        .spawn()?;
-
-    sleep(Duration::from_secs(1));
-
     // Before uploading, check whether the uploaded file does not yet exist.
-    let body = reqwest::blocking::get(format!("http://localhost:{}", port).as_str())?
-        .error_for_status()?;
+    let body = reqwest::blocking::get(server.url())?.error_for_status()?;
     let parsed = Document::from_read(body)?;
     assert!(parsed.find(Text).all(|x| x.text() != test_file_name));
 
@@ -46,37 +30,25 @@ fn uploading_files_works(tmpdir: TempDir, port: u16) -> Result<(), Error> {
 
     let client = Client::new();
     client
-        .post(format!("http://localhost:{}{}", port, upload_action).as_str())
+        .post(server.url().join(upload_action)?)
         .multipart(form)
         .send()?
         .error_for_status()?;
 
     // After uploading, check whether the uploaded file is now getting listed.
-    let body = reqwest::blocking::get(format!("http://localhost:{}", port).as_str())?;
+    let body = reqwest::blocking::get(server.url())?;
     let parsed = Document::from_read(body)?;
     assert!(parsed.find(Text).any(|x| x.text() == test_file_name));
-
-    child.kill()?;
 
     Ok(())
 }
 
 #[rstest]
-fn uploading_files_is_prevented(tmpdir: TempDir, port: u16) -> Result<(), Error> {
+fn uploading_files_is_prevented(server: TestServer) -> Result<(), Error> {
     let test_file_name = "uploaded test file.txt";
 
-    let mut child = Command::cargo_bin("miniserve")?
-        .arg(tmpdir.path())
-        .arg("-p")
-        .arg(port.to_string())
-        .stdout(Stdio::null())
-        .spawn()?;
-
-    sleep(Duration::from_secs(1));
-
     // Before uploading, check whether the uploaded file does not yet exist.
-    let body = reqwest::blocking::get(format!("http://localhost:{}", port).as_str())?
-        .error_for_status()?;
+    let body = reqwest::blocking::get(server.url())?.error_for_status()?;
     let parsed = Document::from_read(body)?;
     assert!(parsed.find(Text).all(|x| x.text() != test_file_name));
 
@@ -93,18 +65,16 @@ fn uploading_files_is_prevented(tmpdir: TempDir, port: u16) -> Result<(), Error>
     let client = Client::new();
     // Ensure uploading fails and returns an error
     assert!(client
-        .post(format!("http://localhost:{}{}", port, "/upload?path=/").as_str())
+        .post(server.url().join("/upload?path=/")?)
         .multipart(form)
         .send()?
         .error_for_status()
         .is_err());
 
     // After uploading, check whether the uploaded file is now getting listed.
-    let body = reqwest::blocking::get(format!("http://localhost:{}", port).as_str())?;
+    let body = reqwest::blocking::get(server.url())?;
     let parsed = Document::from_read(body)?;
     assert!(!parsed.find(Text).any(|x| x.text() == test_file_name));
-
-    child.kill()?;
 
     Ok(())
 }


### PR DESCRIPTION
Remove duplicate code responsible for the initial setup and teardown of
the test binary.

This introduces `TestServer` as a resource manager for a running
miniserve binary, which can be created with the fixtures `server()` and
`server_no_stderr()`

It also provides convenience function for handling server url.