### PR TITLE
Add openssl support for miniserve.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,8 @@ dependencies = [
  "futures-util",
  "http",
  "log",
+ "openssl",
+ "tokio-openssl",
  "trust-dns-proto",
  "trust-dns-resolver",
 ]
@@ -68,6 +70,7 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "actix-threadpool",
+ "actix-tls",
  "actix-utils",
  "base64",
  "bitflags",
@@ -229,6 +232,8 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "futures-util",
+ "openssl",
+ "tokio-openssl",
 ]
 
 [[package]]
@@ -279,6 +284,7 @@ dependencies = [
  "fxhash",
  "log",
  "mime",
+ "openssl",
  "pin-project 1.0.7",
  "regex",
  "serde",
@@ -436,6 +442,7 @@ dependencies = [
  "futures-core",
  "log",
  "mime",
+ "openssl",
  "percent-encoding",
  "rand 0.7.3",
  "serde",
@@ -827,6 +834,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1523,6 +1545,7 @@ dependencies = [
  "maud",
  "mime",
  "nanoid",
+ "openssl",
  "percent-encoding",
  "port_check",
  "pretty_assertions",
@@ -1732,6 +1755,33 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a61075b62a23fef5a29815de7536d940aa35ce96d18ce0cc5076272db678a577"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "313752393519e876837e09e1fa183ddef0be7735868dced3196f4472d536277f"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "output_vt100"
@@ -2828,6 +2878,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-openssl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c4b08c5f4208e699ede3df2520aca2e82401b2de33f45e96696a074480be594"
+dependencies = [
+ "openssl",
+ "tokio 0.2.25",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3082,6 +3142,12 @@ dependencies = [
  "cfg-if 1.0.0",
  "v_escape",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ codegen-units = 1
 panic = 'abort'
 
 [dependencies]
-actix-web = "3"
+actix-web = { version = "3", features = ["openssl"] }
 actix-files = "0.5"
 actix-multipart = "0.3"
 actix-web-httpauth = "0.5"
@@ -49,6 +49,7 @@ httparse = "1"
 http = "0.2"
 bytes = "1"
 atty = "0.2"
+openssl = "0.10"
 
 [dev-dependencies]
 assert_cmd = "1"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Sometimes this is just a more practical and quick way than doing things properly
 - Scan QR code for quick access
 - Shell completions
 - Sane and secure defaults
+- Openssl support
 
 ## Usage
 
@@ -141,7 +142,9 @@ Sometimes this is just a more practical and quick way than doing things properly
                 directory contains this file, miniserve will serve that file instead.
         -i, --interfaces <interfaces>...
                 Interface to listen on
-
+        -C --cacert <openssl-ca>                      Path to opsnssl file: cacert
+        -k --key <openssl-key>                        Path to opsnssl file: key
+            If you would like use openssl, please make sure you have typed both cacert file path and key file path.
         -p, --port <port>
                 Port to use [default: 8080]
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -133,6 +133,14 @@ pub struct CliArgs {
     /// Generate completion file for a shell
     #[structopt(long = "print-completions", value_name = "shell", possible_values = &structopt::clap::Shell::variants())]
     pub print_completions: Option<structopt::clap::Shell>,
+
+    /// Path to opsnssl file: key
+    #[structopt(short = "k", long = "key")]
+    pub openssl_key: Option<String>,
+
+    /// Path to opsnssl file: cacert
+    #[structopt(short = "C", long = "cacert")]
+    pub openssl_ca: Option<String>,
 }
 
 /// Checks wether an interface is valid, i.e. it can be parsed into an IP address


### PR DESCRIPTION
Add openssl support.

To use security http, users can launch miniserve with two more args: 
-C and -K
They are cacert file and key file.
NB: these two args are required simultaneously.

Signed-off-by: Ming Yang <my18345@alumni.bristol.ac.uk>