### PR TITLE
add the ability to create directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ Sometimes this is just a more practical and quick way than doing things properly
 
 (where `$FILE` is the path to the file. This uses miniserve's default port of 8080)
 
+### Creating a directory using `curl`:
+
+    # in one terminal
+    miniserve -m .
+    # in another terminal
+    curl -d "mkdir_name=test_directory" http://localhost:8080/mkdir\?path\=/
+
 ## Features
 
 - Easy to use
@@ -98,6 +105,9 @@ Sometimes this is just a more practical and quick way than doing things properly
                 memory and cannot be sent on the fly
         -u, --upload-files
                 Enable file uploading
+
+        -m, --mkdir
+                Enable creating directory
 
         -h, --help
                 Prints help information

--- a/data/style.scss
+++ b/data/style.scss
@@ -368,25 +368,31 @@ th span.active span {
     margin-right: 1rem;
 }
 
-.upload {
+.toolbar_form_group {
+    display: flex;
+    flex-direction: row;
+}
+
+.toolbar_form {
     margin-top: 1rem;
     display: flex;
     justify-content: flex-end;
+    margin: 0 5px ;
 }
 
-.upload p {
+.toolbar_form p {
     font-size: 0.8rem;
     margin-bottom: 1rem;
     color: var(--upload_text_color);
 }
 
-.upload form {
+.toolbar_form form {
     padding: 1rem;
     border: 1px solid var(--upload_form_border_color);
     background: var(--upload_form_background);
 }
 
-.upload button {
+.toolbar_form button {
     background: var(--upload_button_background);
     padding: 0.5rem;
     border-radius: 0.2rem;
@@ -394,7 +400,7 @@ th span.active span {
     border: none;
 }
 
-.upload div {
+.toolbar_form div {
     display: flex;
     align-items: baseline;
     justify-content: space-between;

--- a/src/args.rs
+++ b/src/args.rs
@@ -95,7 +95,7 @@ pub struct CliArgs {
     #[structopt(short = "u", long = "upload-files")]
     pub file_upload: bool,
 
-    /// Enable create directory
+    /// Enable creating directory
     #[structopt(short = "m", long = "mkdir")]
     pub mkdir: bool,
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -95,6 +95,10 @@ pub struct CliArgs {
     #[structopt(short = "u", long = "upload-files")]
     pub file_upload: bool,
 
+    /// Enable create directory
+    #[structopt(short = "m", long = "mkdir")]
+    pub mkdir: bool,
+
     /// Enable overriding existing files during file upload
     #[structopt(short = "o", long = "overwrite-files")]
     pub overwrite_files: bool,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,6 +14,10 @@ pub enum ContextualError {
     #[error("File already exists, and the overwrite_files option has not been set")]
     DuplicateFileError,
 
+    /// Might occur during mkdir
+    #[error("Directory or file already exist")]
+    ConflictMkdirError,
+
     /// Any error related to an invalid path (failed to retrieve entry name, unexpected entry type, etc)
     #[error("Invalid path\ncaused by: {0}")]
     InvalidPathError(String),

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -33,6 +33,7 @@ pub struct QueryParameters {
     pub path: Option<PathBuf>,
     pub sort: Option<SortingMethod>,
     pub order: Option<SortingOrder>,
+    pub mkdir_name: Option<PathBuf>,
     qrcode: Option<String>,
     download: Option<ArchiveMethod>,
 }
@@ -438,6 +439,7 @@ pub fn extract_query_parameters(req: &HttpRequest) -> QueryParameters {
             download: query.download,
             qrcode: query.qrcode.to_owned(),
             path: query.path.clone(),
+            mkdir_name: query.mkdir_name.clone(),
         },
         Err(e) => {
             let err = ContextualError::ParseError("query parameters".to_string(), e.to_string());
@@ -448,6 +450,7 @@ pub fn extract_query_parameters(req: &HttpRequest) -> QueryParameters {
                 download: None,
                 qrcode: None,
                 path: None,
+                mkdir_name: None,
             }
         }
     }

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -33,9 +33,14 @@ pub struct QueryParameters {
     pub path: Option<PathBuf>,
     pub sort: Option<SortingMethod>,
     pub order: Option<SortingOrder>,
-    pub mkdir_name: Option<PathBuf>,
     qrcode: Option<String>,
     download: Option<ArchiveMethod>,
+}
+
+/// Form parameters
+#[derive(Deserialize)]
+pub struct FormParameters {
+    pub mkdir_name: Option<PathBuf>,
 }
 
 /// Available sorting methods
@@ -157,6 +162,7 @@ pub fn directory_listing(
     skip_symlinks: bool,
     show_hidden: bool,
     file_upload: bool,
+    mkdir: bool,
     random_route: Option<String>,
     favicon_route: String,
     css_route: String,
@@ -164,6 +170,7 @@ pub fn directory_listing(
     default_color_scheme_dark: &str,
     show_qrcode: bool,
     upload_route: String,
+    mkdir_route: String,
     tar_enabled: bool,
     tar_gz_enabled: bool,
     zip_enabled: bool,
@@ -413,7 +420,9 @@ pub fn directory_listing(
                         query_params.order,
                         show_qrcode,
                         file_upload,
+                        mkdir,
                         &upload_route,
+                        &mkdir_route,
                         &favicon_route,
                         &css_route,
                         default_color_scheme,
@@ -439,7 +448,6 @@ pub fn extract_query_parameters(req: &HttpRequest) -> QueryParameters {
             download: query.download,
             qrcode: query.qrcode.to_owned(),
             path: query.path.clone(),
-            mkdir_name: query.mkdir_name.clone(),
         },
         Err(e) => {
             let err = ContextualError::ParseError("query parameters".to_string(), e.to_string());
@@ -450,7 +458,6 @@ pub fn extract_query_parameters(req: &HttpRequest) -> QueryParameters {
                 download: None,
                 qrcode: None,
                 path: None,
-                mkdir_name: None,
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -419,6 +419,7 @@ fn configure_app(app: &mut web::ServiceConfig, conf: &MiniserveConfig) {
         let default_color_scheme_dark = conf.default_color_scheme_dark.clone();
         let show_qrcode = conf.show_qrcode;
         let file_upload = conf.file_upload;
+        let mkdir = conf.mkdir;
         let tar_enabled = conf.tar_enabled;
         let tar_gz_enabled = conf.tar_gz_enabled;
         let zip_enabled = conf.zip_enabled;
@@ -443,6 +444,7 @@ fn configure_app(app: &mut web::ServiceConfig, conf: &MiniserveConfig) {
             )
         } else {
             let u_r = upload_route.clone();
+            let m_r = mkdir_route.clone();
             let files;
             if show_hidden {
                 files = actix_files::Files::new(&full_route, path)
@@ -460,14 +462,15 @@ fn configure_app(app: &mut web::ServiceConfig, conf: &MiniserveConfig) {
                         no_symlinks,
                         show_hidden,
                         file_upload,
+                        mkdir,
                         random_route.clone(),
                         favicon_route.clone(),
                         css_route.clone(),
                         &default_color_scheme,
                         &default_color_scheme_dark,
                         show_qrcode,
-                        // TODO: mkdir path
                         u_r.clone(),
+                        m_r.clone(),
                         tar_enabled,
                         tar_gz_enabled,
                         zip_enabled,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -18,7 +18,9 @@ pub fn page(
     sort_order: Option<SortingOrder>,
     show_qrcode: bool,
     file_upload: bool,
+    mkdir: bool,
     upload_route: &str,
+    mkdir_route: &str,
     favicon_route: &str,
     css_route: &str,
     default_color_scheme: &str,
@@ -31,6 +33,7 @@ pub fn page(
     hide_version_footer: bool,
 ) -> Markup {
     let upload_action = build_upload_action(upload_route, encoded_dir, sort_method, sort_order);
+    let mkdir_action = build_mkdir_action(mkdir_route, encoded_dir, sort_method, sort_order);
 
     let title_path = breadcrumbs
         .iter()
@@ -104,13 +107,26 @@ pub fn page(
                                 }
                             }
                         }
-                        @if file_upload {
-                            div.upload {
-                                form id="file_submit" action=(upload_action) method="POST" enctype="multipart/form-data" {
-                                    p { "Select a file to upload or drag it anywhere into the window" }
-                                    div {
-                                        input#file-input type="file" name="file_to_upload" required="" multiple {}
-                                        button type="submit" { "Upload file" }
+                        div.toolbar_form_group {
+                            @if file_upload {
+                                div.toolbar_form {
+                                    form id="file_submit" action=(upload_action) method="POST" enctype="multipart/form-data" {
+                                        p { "Select a file to upload or drag it anywhere into the window" }
+                                        div {
+                                            input#file-input type="file" name="file_to_upload" required="" multiple {}
+                                            button type="submit" { "Upload file" }
+                                        }
+                                    }
+                                }
+                            }
+                            @if mkdir {
+                                div.toolbar_form {
+                                    form id="mkdir" action=(mkdir_action) method="POST" {
+                                        p { "Specify a directory name to create" }
+                                        div {
+                                            input#mkdir type="text" name="mkdir_name" required="" placeholder="directory name" {}
+                                            button type="submit" { "Create directory" }
+                                        }
                                     }
                                 }
                             }
@@ -161,6 +177,24 @@ fn version_footer() -> Markup {
 
 /// Build the action of the upload form
 fn build_upload_action(
+    upload_route: &str,
+    encoded_dir: &str,
+    sort_method: Option<SortingMethod>,
+    sort_order: Option<SortingOrder>,
+) -> String {
+    let mut upload_action = format!("{}?path={}", upload_route, encoded_dir);
+    if let Some(sorting_method) = sort_method {
+        upload_action = format!("{}&sort={}", upload_action, &sorting_method);
+    }
+    if let Some(sorting_order) = sort_order {
+        upload_action = format!("{}&order={}", upload_action, &sorting_order);
+    }
+
+    upload_action
+}
+
+/// Build the action of the mkdir form
+fn build_mkdir_action(
     upload_route: &str,
     encoded_dir: &str,
     sort_method: Option<SortingMethod>,

--- a/tests/create_directories.rs
+++ b/tests/create_directories.rs
@@ -1,0 +1,107 @@
+mod fixtures;
+
+use assert_cmd::prelude::*;
+use assert_fs::fixture::TempDir;
+use fixtures::{port, tmpdir, Error};
+use reqwest::blocking::Client;
+use rstest::rstest;
+use select::document::Document;
+use select::predicate::{Attr, Text};
+use std::process::{Command, Stdio};
+use std::thread::sleep;
+use std::time::Duration;
+
+#[rstest]
+fn create_directories_works(tmpdir: TempDir, port: u16) -> Result<(), Error> {
+    let test_dir_name = "create_test_dir";
+
+    let mut child = Command::cargo_bin("miniserve")?
+        .arg(tmpdir.path())
+        .arg("-p")
+        .arg(port.to_string())
+        .arg("-m")
+        .stdout(Stdio::null())
+        .spawn()?;
+
+    sleep(Duration::from_secs(1));
+
+    // Before creating, check whether the created directory does not yet exist.
+    let body = reqwest::blocking::get(format!("http://localhost:{}", port).as_str())?
+        .error_for_status()?;
+    let parsed = Document::from_read(body)?;
+    assert!(!parsed
+        .find(Text)
+        .any(|x| x.text() == format!("{}/", test_dir_name)));
+
+    // Perform the actual upload.
+    let mkdir_action = parsed
+        .find(Attr("id", "mkdir"))
+        .next()
+        .expect("Couldn't find element with id=mkdir")
+        .attr("action")
+        .expect("Upload form doesn't have action attribute");
+
+    let client = Client::new();
+    client
+        .post(format!("http://localhost:{}{}", port, mkdir_action).as_str())
+        .form(&[("mkdir_name", test_dir_name)])
+        .send()?
+        .error_for_status()?;
+
+    // After creating, check whether the created directory is now getting listed.
+    let body = reqwest::blocking::get(format!("http://localhost:{}", port).as_str())?;
+    let parsed = Document::from_read(body)?;
+    assert!(parsed
+        .find(Text)
+        .any(|x| x.text() == format!("{}/", test_dir_name)));
+
+    child.kill()?;
+
+    Ok(())
+}
+
+#[rstest]
+fn creating_directories_is_prevented(tmpdir: TempDir, port: u16) -> Result<(), Error> {
+    let test_dir_name = "create_test_dir";
+
+    let mut child = Command::cargo_bin("miniserve")?
+        .arg(tmpdir.path())
+        .arg("-p")
+        .arg(port.to_string())
+        .stdout(Stdio::null())
+        .spawn()?;
+
+    sleep(Duration::from_secs(1));
+
+    // Before creating, check whether the created directory does not yet exist.
+    let body = reqwest::blocking::get(format!("http://localhost:{}", port).as_str())?
+        .error_for_status()?;
+    let parsed = Document::from_read(body)?;
+    assert!(!parsed
+        .find(Text)
+        .any(|x| x.text() == format!("{}/", test_dir_name)));
+
+    // Ensure the create directory form is not present
+    assert!(parsed.find(Attr("id", "mkdir")).next().is_none());
+
+    // Then try to create directory anyway
+    let client = Client::new();
+    // Ensure creating fails and returns an error
+    assert!(client
+        .post(format!("http://localhost:{}{}", port, "/mkdir?path=/").as_str())
+        .form(&[("mkdir_name", test_dir_name)])
+        .send()?
+        .error_for_status()
+        .is_err());
+
+    // After creating, check whether the created directory is now getting listed.
+    let body = reqwest::blocking::get(format!("http://localhost:{}", port).as_str())?;
+    let parsed = Document::from_read(body)?;
+    assert!(!parsed
+        .find(Text)
+        .any(|x| x.text() == format!("{}/", test_dir_name)));
+
+    child.kill()?;
+
+    Ok(())
+}


### PR DESCRIPTION
For #502 

Screenshot
![Screenshot from 2021-04-28 22-36-43](https://user-images.githubusercontent.com/3937480/116422429-532b0b00-a872-11eb-982d-1bba0ba86b0c.png)

* forbid creating directory with colliding name
* forbid creating directory with `parent dir` or `rootdir` in name