### PR TITLE
Compress response using `actix_web::middleware::compress`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -355,6 +355,7 @@ async fn run(miniserve_config: MiniserveConfig) -> Result<(), ContextualError> {
                 HttpAuthentication::basic(auth::handle_auth),
             ))
             .wrap(middleware::Logger::default())
+            .wrap(middleware::Compress::default())
             .route(
                 &format!("/{}", inside_config.favicon_route),
                 web::get().to(favicon),


### PR DESCRIPTION
Using `actix-web` compress middleware to compress the response. Simple benchmark is done using [gtmetrix](https://gtmetrix.com) which shows that the size of content (html, css, svg) shrink from 32.1kB -> 8.6 kB and the page load time is also reduced from 678ms -> 568ms. Though this isn't a thorough benchmark, it shows that it can gain some performance and reduce internet transmission size. Even if the user isn't interested in this feature, the browser could set `accept-encoding` to empty string to opt-out compression.

Related to #497 