### PR TITLE
[Refactor] Fix clippy::too_many_arguments and rework error page rendering

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,11 @@
+use crate::{renderer::render_error, MiniserveConfig};
+use actix_web::{
+    body::AnyBody,
+    dev::{ResponseHead, Service, ServiceRequest, ServiceResponse},
+    http::{header, StatusCode},
+    HttpRequest, HttpResponse, ResponseError,
+};
+use futures::prelude::*;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -50,9 +58,9 @@ pub enum ContextualError {
     #[error("{0}")]
     ArchiveCreationDetailError(String),
 
-    /// Might occur when the HTTP authentication fails
-    #[error("An error occured during HTTP authentication\ncaused by: {0}")]
-    HttpAuthenticationError(Box<ContextualError>),
+    /// Might occur when the HTTP credentials are not provided
+    #[error("Access requires HTTP authentication")]
+    RequireHttpCredentials,
 
     /// Might occur when the HTTP credentials are not correct
     #[error("Invalid credentials for HTTP authentication")]
@@ -74,6 +82,89 @@ Please set an explicit serve path like: `miniserve /my/path`")]
     /// In case miniserve was invoked with --no-symlinks but the serve path is a symlink
     #[error("The -P|--no-symlinks option was provided but the serve path '{0}' is a symlink")]
     NoSymlinksOptionWithSymlinkServePath(String),
+}
+
+impl ResponseError for ContextualError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Self::ArchiveCreationError(_, err) => err.status_code(),
+            Self::RouteNotFoundError(_) => StatusCode::NOT_FOUND,
+            Self::InsufficientPermissionsError(_) => StatusCode::FORBIDDEN,
+            Self::InvalidHttpCredentials | Self::RequireHttpCredentials => StatusCode::UNAUTHORIZED,
+            Self::InvalidHttpRequestError(_) => StatusCode::BAD_REQUEST,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
+    fn error_response(&self) -> HttpResponse {
+        if let Self::RequireHttpCredentials = self {
+        } else {
+            log_error_chain(self.to_string());
+        }
+
+        let mut resp = HttpResponse::build(self.status_code());
+        if let Self::RequireHttpCredentials | Self::InvalidHttpCredentials = self {
+            resp.append_header((
+                header::WWW_AUTHENTICATE,
+                header::HeaderValue::from_static("Basic realm=\"miniserve\""),
+            ));
+        }
+
+        resp.content_type("text/plain; charset=utf-8")
+            .body(self.to_string())
+    }
+}
+
+/// Middleware to convert plain-text error responses to user-friendly web pages
+pub fn error_page_middleware<S>(
+    req: ServiceRequest,
+    srv: &S,
+) -> impl Future<Output = actix_web::Result<ServiceResponse>> + 'static
+where
+    S: Service<ServiceRequest, Response = ServiceResponse, Error = actix_web::Error>,
+    S::Future: 'static,
+{
+    let fut = srv.call(req);
+
+    async {
+        let res = fut.await?;
+
+        if (res.status().is_client_error() || res.status().is_server_error())
+            && res.headers().get(header::CONTENT_TYPE).map(AsRef::as_ref)
+                == Some(b"text/plain; charset=utf-8")
+        {
+            let req = res.request().clone();
+            Ok(res.map_body(|head, body| map_error_page(&req, head, body)))
+        } else {
+            Ok(res)
+        }
+    }
+}
+
+fn map_error_page(req: &HttpRequest, head: &mut ResponseHead, body: AnyBody) -> AnyBody {
+    let error_msg = match &body {
+        AnyBody::Bytes(bytes) => match std::str::from_utf8(bytes) {
+            Ok(msg) => msg,
+            _ => return body,
+        },
+        _ => return body,
+    };
+
+    let conf = req.app_data::<MiniserveConfig>().unwrap();
+    let return_address = req
+        .headers()
+        .get(header::REFERER)
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("/");
+
+    head.headers.insert(
+        header::CONTENT_TYPE,
+        header::HeaderValue::from_static("text/html; charset=utf-8"),
+    );
+
+    render_error(error_msg, head.status, conf, return_address)
+        .into_string()
+        .into()
 }
 
 pub fn log_error_chain(description: String) {

--- a/src/file_upload.rs
+++ b/src/file_upload.rs
@@ -1,16 +1,12 @@
-use actix_web::{
-    http::{header, StatusCode},
-    HttpRequest, HttpResponse,
-};
+use actix_web::{http::header, HttpRequest, HttpResponse};
 use futures::TryStreamExt;
 use std::{
     io::Write,
     path::{Component, PathBuf},
 };
 
-use crate::errors::{self, ContextualError};
-use crate::listing::{self, SortingMethod, SortingOrder};
-use crate::renderer;
+use crate::errors::ContextualError;
+use crate::listing::{self};
 
 /// Create future to save file.
 async fn save_file(
@@ -76,17 +72,10 @@ async fn handle_multipart(
 /// server root directory. Any path which will go outside of this directory is considered
 /// invalid.
 /// This method returns future.
-#[allow(clippy::too_many_arguments)]
 pub async fn upload_file(
     req: HttpRequest,
     payload: actix_web::web::Payload,
-    uses_random_route: bool,
-    favicon_route: String,
-    css_route: String,
-    default_color_scheme: String,
-    default_color_scheme_dark: String,
-    hide_version_footer: bool,
-) -> Result<HttpResponse, actix_web::Error> {
+) -> Result<HttpResponse, ContextualError> {
     let conf = req.app_data::<crate::MiniserveConfig>().unwrap();
     let return_path = if let Some(header) = req.headers().get(header::REFERER) {
         header.to_str().unwrap_or("/").to_owned()
@@ -95,138 +84,32 @@ pub async fn upload_file(
     };
 
     let query_params = listing::extract_query_parameters(&req);
-    let upload_path = match query_params.path.clone() {
-        Some(path) => match path.strip_prefix(Component::RootDir) {
-            Ok(stripped_path) => stripped_path.to_owned(),
-            Err(_) => path.clone(),
-        },
-        None => {
-            let err = ContextualError::InvalidHttpRequestError(
-                "Missing query parameter 'path'".to_string(),
-            );
-            return Ok(create_error_response(
-                &err.to_string(),
-                StatusCode::BAD_REQUEST,
-                &return_path,
-                query_params.sort,
-                query_params.order,
-                uses_random_route,
-                &favicon_route,
-                &css_route,
-                &default_color_scheme,
-                &default_color_scheme_dark,
-                hide_version_footer,
-            ));
-        }
-    };
+    let upload_path = query_params.path.as_ref().ok_or_else(|| {
+        ContextualError::InvalidHttpRequestError("Missing query parameter 'path'".to_string())
+    })?;
+    let upload_path = upload_path
+        .strip_prefix(Component::RootDir)
+        .unwrap_or(upload_path);
 
-    let app_root_dir = match conf.path.canonicalize() {
-        Ok(dir) => dir,
-        Err(e) => {
-            let err = ContextualError::IoError(
-                "Failed to resolve path served by miniserve".to_string(),
-                e,
-            );
-            return Ok(create_error_response(
-                &err.to_string(),
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &return_path,
-                query_params.sort,
-                query_params.order,
-                uses_random_route,
-                &favicon_route,
-                &css_route,
-                &default_color_scheme,
-                &default_color_scheme_dark,
-                hide_version_footer,
-            ));
-        }
-    };
+    let app_root_dir = conf.path.canonicalize().map_err(|e| {
+        ContextualError::IoError("Failed to resolve path served by miniserve".to_string(), e)
+    })?;
 
     // If the target path is under the app root directory, save the file.
-    let target_dir = match &app_root_dir.join(upload_path).canonicalize() {
-        Ok(path) if path.starts_with(&app_root_dir) => path.clone(),
-        _ => {
-            let err = ContextualError::InvalidHttpRequestError(
-                "Invalid value for 'path' parameter".to_string(),
-            );
-            return Ok(create_error_response(
-                &err.to_string(),
-                StatusCode::BAD_REQUEST,
-                &return_path,
-                query_params.sort,
-                query_params.order,
-                uses_random_route,
-                &favicon_route,
-                &css_route,
-                &default_color_scheme,
-                &default_color_scheme_dark,
-                hide_version_footer,
-            ));
-        }
-    };
-    let overwrite_files = conf.overwrite_files;
-    let default_color_scheme = conf.default_color_scheme.clone();
-    let default_color_scheme_dark = conf.default_color_scheme_dark.clone();
-
-    match actix_multipart::Multipart::new(req.headers(), payload)
-        .map_err(ContextualError::MultipartError)
-        .and_then(move |field| handle_multipart(field, target_dir.clone(), overwrite_files))
-        .try_collect::<Vec<u64>>()
-        .await
-    {
-        Ok(_) => Ok(HttpResponse::SeeOther()
-            .append_header((header::LOCATION, return_path))
-            .finish()),
-        Err(e) => Ok(create_error_response(
-            &e.to_string(),
-            StatusCode::INTERNAL_SERVER_ERROR,
-            &return_path,
-            query_params.sort,
-            query_params.order,
-            uses_random_route,
-            &favicon_route,
-            &css_route,
-            &default_color_scheme,
-            &default_color_scheme_dark,
-            hide_version_footer,
+    let target_dir = match app_root_dir.join(upload_path).canonicalize() {
+        Ok(path) if path.starts_with(&app_root_dir) => Ok(path),
+        _ => Err(ContextualError::InvalidHttpRequestError(
+            "Invalid value for 'path' parameter".to_string(),
         )),
-    }
-}
+    }?;
 
-/// Convenience method for creating response errors, if file upload fails.
-#[allow(clippy::too_many_arguments)]
-fn create_error_response(
-    description: &str,
-    error_code: StatusCode,
-    return_path: &str,
-    sorting_method: Option<SortingMethod>,
-    sorting_order: Option<SortingOrder>,
-    uses_random_route: bool,
-    favicon_route: &str,
-    css_route: &str,
-    default_color_scheme: &str,
-    default_color_scheme_dark: &str,
-    hide_version_footer: bool,
-) -> HttpResponse {
-    errors::log_error_chain(description.to_string());
-    HttpResponse::BadRequest()
-        .content_type("text/html; charset=utf-8")
-        .body(
-            renderer::render_error(
-                description,
-                error_code,
-                return_path,
-                sorting_method,
-                sorting_order,
-                true,
-                !uses_random_route,
-                favicon_route,
-                css_route,
-                default_color_scheme,
-                default_color_scheme_dark,
-                hide_version_footer,
-            )
-            .into_string(),
-        )
+    actix_multipart::Multipart::new(req.headers(), payload)
+        .map_err(ContextualError::MultipartError)
+        .and_then(|field| handle_multipart(field, target_dir.clone(), conf.overwrite_files))
+        .try_collect::<Vec<u64>>()
+        .await?;
+
+    Ok(HttpResponse::SeeOther()
+        .append_header((header::LOCATION, return_path))
+        .finish())
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -485,6 +485,16 @@ pub fn render_error(
             body.(format!("default_theme_{}", conf.default_color_scheme))
                 .(format!("default_theme_dark_{}", conf.default_color_scheme_dark)) {
 
+                (PreEscaped(r#"
+                    <script>
+                        // read theme from local storage and apply it to body
+                        var theme = localStorage.getItem('theme');
+                        if (theme != null && theme != 'default') {
+                            document.body.classList.add('theme_' + theme);
+                        }
+                    </script>
+                    "#))
+
                 div.error {
                     p { (error_code.to_string()) }
                     @for error in error_description.lines() {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -6,31 +6,24 @@ use maud::{html, Markup, PreEscaped, DOCTYPE};
 use std::time::SystemTime;
 use strum::IntoEnumIterator;
 
-use crate::archive::ArchiveMethod;
-use crate::listing::{Breadcrumb, Entry, SortingMethod, SortingOrder};
+use crate::listing::{Breadcrumb, Entry, QueryParameters, SortingMethod, SortingOrder};
+use crate::{archive::ArchiveMethod, MiniserveConfig};
 
 /// Renders the file listing
-#[allow(clippy::too_many_arguments)]
 pub fn page(
     entries: Vec<Entry>,
     is_root: bool,
-    sort_method: Option<SortingMethod>,
-    sort_order: Option<SortingOrder>,
-    show_qrcode: bool,
-    file_upload: bool,
-    upload_route: &str,
-    favicon_route: &str,
-    css_route: &str,
-    default_color_scheme: &str,
-    default_color_scheme_dark: &str,
-    encoded_dir: &str,
+    query_params: QueryParameters,
     breadcrumbs: Vec<Breadcrumb>,
-    tar_enabled: bool,
-    tar_gz_enabled: bool,
-    zip_enabled: bool,
-    hide_version_footer: bool,
+    encoded_dir: &str,
+    conf: &MiniserveConfig,
 ) -> Markup {
-    let upload_action = build_upload_action(upload_route, encoded_dir, sort_method, sort_order);
+    let upload_route = match conf.random_route {
+        Some(ref random_route) => format!("/{}/upload", random_route),
+        None => "/upload".to_string(),
+    };
+    let (sort_method, sort_order) = (query_params.sort, query_params.order);
+    let upload_action = build_upload_action(&upload_route, encoded_dir, sort_method, sort_order);
 
     let title_path = breadcrumbs
         .iter()
@@ -41,11 +34,11 @@ pub fn page(
     html! {
         (DOCTYPE)
         html {
-            (page_header(&title_path, file_upload, favicon_route, css_route))
+            (page_header(&title_path, conf.file_upload, &conf.favicon_route, &conf.css_route))
 
             body#drop-container
-                .(format!("default_theme_{}", default_color_scheme))
-                .(format!("default_theme_dark_{}", default_color_scheme_dark)) {
+                .(format!("default_theme_{}", conf.default_color_scheme))
+                .(format!("default_theme_dark_{}", conf.default_color_scheme_dark)) {
 
                 (PreEscaped(r#"
                     <script>
@@ -71,14 +64,14 @@ pub fn page(
                     </script>
                     "#))
 
-                @if file_upload {
+                @if conf.file_upload {
                     div.drag-form {
                         div.drag-title {
                             h1 { "Drop your file here to upload it" }
                         }
                     }
                 }
-                (color_scheme_selector(show_qrcode))
+                (color_scheme_selector(conf.show_qrcode))
                 div.container {
                     span#top { }
                     h1.title dir="ltr" {
@@ -95,16 +88,16 @@ pub fn page(
                         }
                     }
                     div.toolbar {
-                        @if tar_enabled || tar_gz_enabled || zip_enabled {
+                        @if conf.tar_enabled || conf.tar_gz_enabled || conf.zip_enabled {
                             div.download {
                                 @for archive_method in ArchiveMethod::iter() {
-                                    @if archive_method.is_enabled(tar_enabled, tar_gz_enabled, zip_enabled) {
+                                    @if archive_method.is_enabled(conf.tar_enabled, conf.tar_gz_enabled, conf.zip_enabled) {
                                         (archive_button(archive_method, sort_method, sort_order))
                                     }
                                 }
                             }
                         }
-                        @if file_upload {
+                        @if conf.file_upload {
                             div.upload {
                                 form id="file_submit" action=(upload_action) method="POST" enctype="multipart/form-data" {
                                     p { "Select a file to upload or drag it anywhere into the window" }
@@ -141,7 +134,7 @@ pub fn page(
                     a.back href="#top" {
                         (arrow_up())
                     }
-                    @if !hide_version_footer {
+                    @if !conf.hide_version_footer {
                         (version_footer())
                     }
                 }
@@ -478,48 +471,34 @@ fn humanize_systemtime(time: Option<SystemTime>) -> Option<String> {
 }
 
 /// Renders an error on the webpage
-#[allow(clippy::too_many_arguments)]
 pub fn render_error(
     error_description: &str,
     error_code: StatusCode,
+    conf: &MiniserveConfig,
     return_address: &str,
-    sort_method: Option<SortingMethod>,
-    sort_order: Option<SortingOrder>,
-    has_referer: bool,
-    display_back_link: bool,
-    favicon_route: &str,
-    css_route: &str,
-    default_color_scheme: &str,
-    default_color_scheme_dark: &str,
-    hide_version_footer: bool,
 ) -> Markup {
-    let link = if has_referer {
-        return_address.to_string()
-    } else {
-        parametrized_link(return_address, sort_method, sort_order)
-    };
-
     html! {
         (DOCTYPE)
         html {
-            (page_header(&error_code.to_string(), false, favicon_route, css_route))
+            (page_header(&error_code.to_string(), false, &conf.favicon_route, &conf.css_route))
 
-            body.(format!("default_theme_{}", default_color_scheme))
-                .(format!("default_theme_dark_{}", default_color_scheme_dark)) {
+            body.(format!("default_theme_{}", conf.default_color_scheme))
+                .(format!("default_theme_dark_{}", conf.default_color_scheme_dark)) {
 
                 div.error {
                     p { (error_code.to_string()) }
                     @for error in error_description.lines() {
                         p { (error) }
                     }
-                    @if display_back_link {
+                    // WARN don't expose random route!
+                    @if !conf.random_route.is_some() {
                         div.error-nav {
-                            a.error-back href=(link) {
+                            a.error-back href=(return_address) {
                                 "Go back to file listing"
                             }
                         }
                     }
-                    @if !hide_version_footer {
+                    @if !conf.hide_version_footer {
                         (version_footer())
                     }
                 }


### PR DESCRIPTION
Too many arguments are moved around and many of them are already stored in `MiniserveConfig`. Many of these are used to render error pages.

To fix this issue, it was necessary to rework error page rendering:

1. Implement `ResponseError` for `ContextualError` so that it can be
   returned from service handlers as is and will then be automatically
   logged to the console and converted into an error response.

2. At service handler level, all error responses are now rendered as
   plain text.

3. `error_page_middleware` is now responsible for the rendering of the
   final error page from plain text responses.

Based on #513 

Closes #588