### PR TITLE
Only allow file uploads within served directory

### DIFF
--- a/src/file_upload.rs
+++ b/src/file_upload.rs
@@ -51,7 +51,6 @@ fn save_file(
 fn handle_multipart(
     field: actix_multipart::Field,
     mut file_path: PathBuf,
-    app_root_dir: PathBuf,
     overwrite_files: bool,
 ) -> Pin<Box<dyn Stream<Item = Result<i64, ContextualError>>>> {
     let filename = field
@@ -73,8 +72,8 @@ fn handle_multipart(
             // Without this check, attackers can mount an attack via path traversal by
             // manipulating the filename attribute in the multipart request in the
             // ways enumerated on this page: https://cwe.mitre.org/data/definitions/22.html
-            match &app_root_dir.join(&f).canonicalize() {
-                Ok(path) if path.starts_with(&app_root_dir) => (),
+            match &file_path.join(&f).canonicalize() {
+                Ok(path) if path.starts_with(&file_path) => (),
                 _ => {
                     return err(ContextualError::InvalidPathError(
                         "invalid path".to_string(),

--- a/src/file_upload.rs
+++ b/src/file_upload.rs
@@ -210,14 +210,7 @@ pub fn upload_file(
     Box::pin(
         actix_multipart::Multipart::new(req.headers(), payload)
             .map_err(ContextualError::MultipartError)
-            .map_ok(move |item| {
-                handle_multipart(
-                    item,
-                    target_dir.clone(),
-                    app_root_dir.clone(),
-                    overwrite_files,
-                )
-            })
+            .map_ok(move |item| handle_multipart(item, target_dir.clone(), overwrite_files))
             .try_flatten()
             .try_collect::<Vec<_>>()
             .then(move |e| match e {


### PR DESCRIPTION
Before this commit, the only user input that was checked for path
traversal attacks was the path query parameter.

This commit adds a check that ensures the final file path including the
filename parameter from the multipart body is within the served directory.

Potentially closes #518