### PR TITLE
Conditionally enable TLS only on supported platforms

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,7 @@ jobs:
             cross: true
             strip: true
             compress: true
+            cargo_flags: ""
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
             artifact_name: target/aarch64-unknown-linux-musl/release/miniserve
@@ -39,6 +40,7 @@ jobs:
             cross: true
             strip: false
             compress: true
+            cargo_flags: ""
           - os: ubuntu-latest
             target: armv7-unknown-linux-musleabihf
             artifact_name: target/armv7-unknown-linux-musleabihf/release/miniserve
@@ -46,6 +48,7 @@ jobs:
             cross: true
             strip: false
             compress: true
+            cargo_flags: ""
           - os: ubuntu-latest
             target: arm-unknown-linux-musleabihf
             artifact_name: target/arm-unknown-linux-musleabihf/release/miniserve
@@ -53,6 +56,7 @@ jobs:
             cross: true
             strip: false
             compress: true
+            cargo_flags: ""
           - os: ubuntu-latest
             target: mips-unknown-linux-musl
             artifact_name: target/mips-unknown-linux-musl/release/miniserve
@@ -60,6 +64,7 @@ jobs:
             cross: true
             strip: false
             compress: true
+            cargo_flags: "--no-default-features"
           - os: ubuntu-latest
             target: mipsel-unknown-linux-musl
             artifact_name: target/mipsel-unknown-linux-musl/release/miniserve
@@ -67,6 +72,7 @@ jobs:
             cross: true
             strip: false
             compress: true
+            cargo_flags: "--no-default-features"
           - os: ubuntu-latest
             target: mips64-unknown-linux-gnuabi64
             artifact_name: target/mips64-unknown-linux-gnuabi64/release/miniserve
@@ -74,6 +80,7 @@ jobs:
             cross: true
             strip: false
             compress: false
+            cargo_flags: "--no-default-features"
           - os: ubuntu-latest
             target: mips64el-unknown-linux-gnuabi64
             artifact_name: target/mips64el-unknown-linux-gnuabi64/release/miniserve
@@ -81,6 +88,7 @@ jobs:
             cross: true
             strip: false
             compress: false
+            cargo_flags: "--no-default-features"
           - os: ubuntu-latest
             target: riscv64gc-unknown-linux-gnu
             artifact_name: target/riscv64gc-unknown-linux-gnu/release/miniserve
@@ -88,6 +96,7 @@ jobs:
             cross: true
             strip: false
             compress: false
+            cargo_flags: "--no-default-features"
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact_name: target/x86_64-pc-windows-msvc/release/miniserve.exe
@@ -95,6 +104,7 @@ jobs:
             cross: false
             strip: true
             compress: true
+            cargo_flags: ""
           - os: macos-latest
             target: x86_64-apple-darwin
             artifact_name: target/x86_64-apple-darwin/release/miniserve
@@ -102,6 +112,7 @@ jobs:
             cross: false
             strip: true
             compress: true
+            cargo_flags: ""
           - os: ubuntu-latest
             target: x86_64-unknown-freebsd
             artifact_name: target/x86_64-unknown-freebsd/release/miniserve
@@ -109,6 +120,7 @@ jobs:
             cross: true
             strip: false
             compress: false
+            cargo_flags: ""
 
     steps:
       - name: Checkout code
@@ -124,7 +136,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --locked --target=${{ matrix.target }}
+          args: --release --locked --target=${{ matrix.target }} ${{ matrix.cargo_flags }}
           use-cross: ${{ matrix.cross }}
 
       - name: Compress binaries

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["serve", "http-server", "static-files", "http", "server"]
 categories = ["command-line-utilities", "network-programming", "web-programming::http-server"]
 edition = "2018"
+resolver = "2"
 
 [profile.release]
 lto = true
@@ -17,7 +18,7 @@ codegen-units = 1
 panic = 'abort'
 
 [dependencies]
-actix-web = { version = "3", features = ["rustls"] }
+actix-web = "3"
 actix-files = "0.5"
 actix-multipart = "0.3"
 actix-web-httpauth = "0.5"
@@ -50,7 +51,14 @@ httparse = "1"
 http = "0.2"
 bytes = "1"
 atty = "0.2"
+
+# Use rustls only on architecturs supported by ring.
+# See also https://github.com/briansmith/ring/issues/1182
+# and https://github.com/briansmith/ring/issues/562
+# and https://github.com/briansmith/ring/issues/1367
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64", target_arch = "arm"))'.dependencies]
 rustls = "0.18"
+actix-web = { version = "3", features = ["rustls"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,14 +51,15 @@ httparse = "1"
 http = "0.2"
 bytes = "1"
 atty = "0.2"
+rustls = { version = "0.18", optional = true }
 
-# Use rustls only on architecturs supported by ring.
+[features]
+default = ["tls"]
+# This feature allows us to use rustls only on architectures supported by ring.
 # See also https://github.com/briansmith/ring/issues/1182
 # and https://github.com/briansmith/ring/issues/562
 # and https://github.com/briansmith/ring/issues/1367
-[target.'cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64", target_arch = "arm"))'.dependencies]
-rustls = "0.18"
-actix-web = { version = "3", features = ["rustls"] }
+tls = ["rustls", "actix-web/rustls"]
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Sometimes this is just a more practical and quick way than doing things properly
 - Scan QR code for quick access
 - Shell completions
 - Sane and secure defaults
+- TLS (for supported architectures)
 
 ## Usage
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -135,22 +135,12 @@ pub struct CliArgs {
     pub print_completions: Option<structopt::clap::Shell>,
 
     /// TLS certificate to use
-    #[cfg(any(
-        target_arch = "x86",
-        target_arch = "x86_64",
-        target_arch = "aarch64",
-        target_arch = "arm"
-    ))]
+    #[cfg(feature = "tls")]
     #[structopt(long = "tls-cert", requires = "tls-key")]
     pub tls_cert: Option<PathBuf>,
 
     /// TLS private key to use
-    #[cfg(any(
-        target_arch = "x86",
-        target_arch = "x86_64",
-        target_arch = "aarch64",
-        target_arch = "arm"
-    ))]
+    #[cfg(feature = "tls")]
     #[structopt(long = "tls-key", requires = "tls-cert")]
     pub tls_key: Option<PathBuf>,
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -135,10 +135,22 @@ pub struct CliArgs {
     pub print_completions: Option<structopt::clap::Shell>,
 
     /// TLS certificate to use
+    #[cfg(any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "arm"
+    ))]
     #[structopt(long = "tls-cert", requires = "tls-key")]
     pub tls_cert: Option<PathBuf>,
 
     /// TLS private key to use
+    #[cfg(any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "arm"
+    ))]
     #[structopt(long = "tls-key", requires = "tls-cert")]
     pub tls_key: Option<PathBuf>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,12 +8,7 @@ use std::{
 use anyhow::{anyhow, Context, Result};
 use http::HeaderMap;
 
-#[cfg(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    target_arch = "aarch64",
-    target_arch = "arm"
-))]
+#[cfg(feature = "tls")]
 use rustls::internal::pemfile::{certs, pkcs8_private_keys};
 
 use crate::{args::CliArgs, auth::RequiredAuth};
@@ -102,20 +97,10 @@ pub struct MiniserveConfig {
     pub hide_version_footer: bool,
 
     /// If set, use provided rustls config for TLS
-    #[cfg(any(
-        target_arch = "x86",
-        target_arch = "x86_64",
-        target_arch = "aarch64",
-        target_arch = "arm"
-    ))]
+    #[cfg(feature = "tls")]
     pub tls_rustls_config: Option<rustls::ServerConfig>,
 
-    #[cfg(not(any(
-        target_arch = "x86",
-        target_arch = "x86_64",
-        target_arch = "aarch64",
-        target_arch = "arm"
-    )))]
+    #[cfg(not(feature = "tls"))]
     pub tls_rustls_config: Option<()>,
 }
 
@@ -152,12 +137,7 @@ impl MiniserveConfig {
             _ => args.port,
         };
 
-        #[cfg(any(
-            target_arch = "x86",
-            target_arch = "x86_64",
-            target_arch = "aarch64",
-            target_arch = "arm"
-        ))]
+        #[cfg(feature = "tls")]
         let tls_rustls_server_config = if let (Some(tls_cert), Some(tls_key)) =
             (args.tls_cert, args.tls_key)
         {
@@ -178,12 +158,7 @@ impl MiniserveConfig {
             None
         };
 
-        #[cfg(not(any(
-            target_arch = "x86",
-            target_arch = "x86_64",
-            target_arch = "aarch64",
-            target_arch = "arm"
-        )))]
+        #[cfg(not(feature = "tls"))]
         let tls_rustls_server_config = None;
 
         Ok(MiniserveConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,13 @@ use std::{
 
 use anyhow::{anyhow, Context, Result};
 use http::HeaderMap;
+
+#[cfg(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "arm"
+))]
 use rustls::internal::pemfile::{certs, pkcs8_private_keys};
 
 use crate::{args::CliArgs, auth::RequiredAuth};
@@ -95,7 +102,21 @@ pub struct MiniserveConfig {
     pub hide_version_footer: bool,
 
     /// If set, use provided rustls config for TLS
+    #[cfg(any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "arm"
+    ))]
     pub tls_rustls_config: Option<rustls::ServerConfig>,
+
+    #[cfg(not(any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "arm"
+    )))]
+    pub tls_rustls_config: Option<()>,
 }
 
 impl MiniserveConfig {
@@ -131,6 +152,12 @@ impl MiniserveConfig {
             _ => args.port,
         };
 
+        #[cfg(any(
+            target_arch = "x86",
+            target_arch = "x86_64",
+            target_arch = "aarch64",
+            target_arch = "arm"
+        ))]
         let tls_rustls_server_config = if let (Some(tls_cert), Some(tls_key)) =
             (args.tls_cert, args.tls_key)
         {
@@ -150,6 +177,15 @@ impl MiniserveConfig {
         } else {
             None
         };
+
+        #[cfg(not(any(
+            target_arch = "x86",
+            target_arch = "x86_64",
+            target_arch = "aarch64",
+            target_arch = "arm"
+        )))]
+        let tls_rustls_server_config = None;
+
         Ok(MiniserveConfig {
             verbose: args.verbose,
             path: args.path.unwrap_or_else(|| PathBuf::from(".")),

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,12 +227,7 @@ async fn run(miniserve_config: MiniserveConfig) -> Result<(), ContextualError> {
             .default_service(web::get().to(error_404))
     });
 
-    #[cfg(any(
-        target_arch = "x86",
-        target_arch = "x86_64",
-        target_arch = "aarch64",
-        target_arch = "arm"
-    ))]
+    #[cfg(feature = "tls")]
     let srv = if let Some(tls_config) = miniserve_config.tls_rustls_config {
         srv.bind_rustls(socket_addresses.as_slice(), tls_config)
             .map_err(|e| ContextualError::IoError("Failed to bind server".to_string(), e))?
@@ -245,12 +240,7 @@ async fn run(miniserve_config: MiniserveConfig) -> Result<(), ContextualError> {
             .run()
     };
 
-    #[cfg(not(any(
-        target_arch = "x86",
-        target_arch = "x86_64",
-        target_arch = "aarch64",
-        target_arch = "arm"
-    )))]
+    #[cfg(not(feature = "tls"))]
     let srv = srv
         .bind(socket_addresses.as_slice())
         .map_err(|e| ContextualError::IoError("Failed to bind server".to_string(), e))?

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,6 +227,12 @@ async fn run(miniserve_config: MiniserveConfig) -> Result<(), ContextualError> {
             .default_service(web::get().to(error_404))
     });
 
+    #[cfg(any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "arm"
+    ))]
     let srv = if let Some(tls_config) = miniserve_config.tls_rustls_config {
         srv.bind_rustls(socket_addresses.as_slice(), tls_config)
             .map_err(|e| ContextualError::IoError("Failed to bind server".to_string(), e))?
@@ -238,6 +244,18 @@ async fn run(miniserve_config: MiniserveConfig) -> Result<(), ContextualError> {
             .shutdown_timeout(0)
             .run()
     };
+
+    #[cfg(not(any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "arm"
+    )))]
+    let srv = srv
+        .bind(socket_addresses.as_slice())
+        .map_err(|e| ContextualError::IoError("Failed to bind server".to_string(), e))?
+        .shutdown_timeout(0)
+        .run();
 
     println!(
         "Serving path {path} at {addresses}",


### PR DESCRIPTION
Use rustls only on architecturs supported by ring. See also https://github.com/briansmith/ring/issues/1182 and https://github.com/briansmith/ring/issues/562 and https://github.com/briansmith/ring/issues/1367