### PR TITLE
Always build all binaries for all targets

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -1,12 +1,9 @@
-name: Publish
+name: Build release binaries (and publish them if this is a tag)
 
-on:
-  push:
-    tags:
-      - 'v*'
+on: push
 
 jobs:
-  publish:
+  binaries:
     name: ${{ matrix.os }} for ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -147,11 +144,16 @@ jobs:
           strip: ${{ matrix.strip }}
         if: ${{ matrix.compress }}
 
+      ###
+      # Below this line, steps will only be ran if a tag was pushed.
+      ###
+
       - name: Get tag name
         id: tag_name
         run: |
           echo ::set-output name=current_version::${GITHUB_REF#refs/tags/v}
         shell: bash
+        if: startsWith('refs/tags/v', github.ref)
 
       - name: Get CHANGELOG.md entry
         id: changelog_reader
@@ -159,8 +161,9 @@ jobs:
         with:
           version: ${{ steps.tag_name.outputs.current_version }}
           path: ./CHANGELOG.md
+        if: startsWith('refs/tags/v', github.ref)
 
-      - name: Release
+      - name: Publish
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -168,3 +171,4 @@ jobs:
           tag: ${{ github.ref }}
           asset_name: miniserve-$tag-${{ matrix.release_name }}
           body: ${{ steps.changelog_reader.outputs.log_entry }}
+        if: startsWith('refs/tags/v', github.ref)

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,3 +1,5 @@
 # NOTE: Custom image specification for freebsd is required until new version of cross is released.
+# Also we'll have to use a custom image until https://github.com/rust-embedded/cross/pull/582 is
+# merged and released on Docker Hub.
 [target.x86_64-unknown-freebsd]
-image = "rustembedded/cross:x86_64-unknown-freebsd"
+image = "svenstaro/cross-x86_64-unknown-freebsd"


### PR DESCRIPTION
This uses the original workflow we used for publishing the binaries but now we
use it as CI as well with an optional publish in case we are in a tag push.