### PR TITLE
Upload artifacts when building release binaries

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -147,6 +147,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
+          name: ${{ matrix.target }}
           path: ${{ matrix.artifact_name }}
 
       ###

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -144,6 +144,11 @@ jobs:
           strip: ${{ matrix.strip }}
         if: ${{ matrix.compress }}
 
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: ${{ matrix.artifact_name }}
+
       ###
       # Below this line, steps will only be ran if a tag was pushed.
       ###

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -6,6 +6,7 @@ jobs:
   binaries:
     name: ${{ matrix.os }} for ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       matrix:
         target:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
   ci:
     name: ${{ matrix.rust }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]


### PR DESCRIPTION
We always do this unconditionally so that we can even check out artifacts from PRs.