### PR TITLE
Use custom FreeBSD image until cross is fixed

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,3 +1,3 @@
 # NOTE: Custom image specification for freebsd is required until new version of cross is released.
 [target.x86_64-unknown-freebsd]
-image = "rustembedded/cross:x86_64-unknown-freebsd"
+image = "svenstaro/cross-x86_64-unknown-freebsd:latest"


### PR DESCRIPTION
We're currently waiting on https://github.com/cross-rs/cross/pull/613 and https://github.com/cross-rs/cross/pull/620
to be merged and released for cross. Until then, we're fixing this ourselves downstream with a custom FreeBSD image.