### PR TITLE
Add a flag to enable image uploads

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -104,6 +104,10 @@ pub struct CliArgs {
     #[clap(short = 'u', long = "upload-files")]
     pub file_upload: bool,
 
+    /// Enable image uploading
+    #[clap(short = 'I', long = "upload-images")]
+    pub image_upload: bool,
+
     /// Enable overriding existing files during file upload
     #[clap(short = 'o', long = "overwrite-files")]
     pub overwrite_files: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -81,6 +81,9 @@ pub struct MiniserveConfig {
     /// Enable file upload
     pub file_upload: bool,
 
+    /// Set the input type for file uploads to image, allowing to take pictures from some browsers on smartphones
+    pub image_upload: bool,
+
     /// Enable upload to override existing files
     pub overwrite_files: bool,
 
@@ -188,6 +191,8 @@ impl MiniserveConfig {
         #[cfg(not(feature = "tls"))]
         let tls_rustls_server_config = None;
 
+        let file_upload = args.file_upload || args.image_upload;
+
         Ok(MiniserveConfig {
             verbose: args.verbose,
             path: args.path.unwrap_or_else(|| PathBuf::from(".")),
@@ -206,7 +211,8 @@ impl MiniserveConfig {
             spa: args.spa,
             overwrite_files: args.overwrite_files,
             show_qrcode: args.qrcode,
-            file_upload: args.file_upload,
+            file_upload,
+            image_upload: args.image_upload,
             tar_enabled: args.enable_tar,
             tar_gz_enabled: args.enable_tar_gz,
             zip_enabled: args.enable_zip,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -107,7 +107,11 @@ pub fn page(
                                 form id="file_submit" action=(upload_action) method="POST" enctype="multipart/form-data" {
                                     p { "Select a file to upload or drag it anywhere into the window" }
                                     div {
-                                        input #file-input type="file" name="file_to_upload" required="" multiple {}
+                                        @if conf.image_upload {
+                                            input #file-input type="file" accept="image/*" name="file_to_upload" required="" multiple {}
+                                        } @else {
+                                            input #file-input type="file" name="file_to_upload" required="" multiple {}
+                                        }
                                         button type="submit" { "Upload file" }
                                     }
                                 }


### PR DESCRIPTION
This implements the feature I asked about in #546.
An additional flag allows to add the `accept="image/*"` attribute to the file input.