### PR TITLE
docs: add installation via Cask section

### DIFF
--- a/Cask.toml
+++ b/Cask.toml
@@ -7,4 +7,4 @@ description = """
 """
 
 [darwin]
-x86_64 = "https://github.com/svenstaro/miniserve/releases/download/v{version}/miniserve-v{version}-x86_64-apple-darwin"
+x86_64 = { executable = "https://github.com/svenstaro/miniserve/releases/download/v{version}/miniserve-v{version}-x86_64-apple-darwin"}

--- a/Cask.toml
+++ b/Cask.toml
@@ -8,3 +8,20 @@ description = """
 
 [darwin]
 x86_64 = { executable = "https://github.com/svenstaro/miniserve/releases/download/v{version}/miniserve-v{version}-x86_64-apple-darwin"}
+aarch64 = { executable = "https://github.com/svenstaro/miniserve/releases/download/v{version}/miniserve-v{version}-aarch64-apple-darwin"}
+
+[windows]
+x86_64 = { executable = "https://github.com/svenstaro/miniserve/releases/download/v{version}/miniserve-v{version}-x86_64-pc-windows-msvc.exe"}
+
+[linux]
+x86_64 = { executable = "https://github.com/svenstaro/miniserve/releases/download/v{version}/miniserve-v{version}-x86_64-unknown-linux-musl"}
+arm = { executable = "https://github.com/svenstaro/miniserve/releases/download/v{version}/miniserve-v{version}-arm-unknown-linux-musleabihf"}
+armv7 = { executable = "https://github.com/svenstaro/miniserve/releases/download/v{version}/miniserve-v{version}-armv7-unknown-linux-musleabihf"}
+aarch64 = { executable = "https://github.com/svenstaro/miniserve/releases/download/v{version}/miniserve-v{version}-aarch64-unknown-linux-musl"}
+mips = { executable = "https://github.com/svenstaro/miniserve/releases/download/v{version}/miniserve-v{version}-mips-unknown-linux-musl"}
+mips64 = { executable = "https://github.com/svenstaro/miniserve/releases/download/v{version}/miniserve-v{version}-mips64-unknown-linux-gnuabi64"}
+mips64el = { executable = "https://github.com/svenstaro/miniserve/releases/download/v{version}/miniserve-v{version}-mips64el-unknown-linux-gnuabi64"}
+riscv64 = { executable = "https://github.com/svenstaro/miniserve/releases/download/v{version}/miniserve-v{version}-riscv64gc-unknown-linux-gnu"}
+
+[freebsd]
+x86_64 = { executable = "https://github.com/svenstaro/miniserve/releases/download/v{version}/miniserve-v{version}-x86_64-unknown-freebsd" }

--- a/Cask.toml
+++ b/Cask.toml
@@ -1,0 +1,10 @@
+[package]
+name = "github.com/svenstaro/miniserve"
+bin = "miniserve"
+repository = "https://github.com/svenstaro/miniserve"
+description = """
+🌟 For when you really just want to serve some files over HTTP right now!
+"""
+
+[darwin]
+x86_64 = "https://github.com/svenstaro/miniserve/releases/download/v{version}/miniserve-v{version}-x86_64-apple-darwin"

--- a/README.md
+++ b/README.md
@@ -276,6 +276,10 @@ Alternatively install with [Scoop](https://scoop.sh/):
 
     podman run -v /tmp:/tmp -p 8080:8080 --rm -it docker.io/svenstaro/miniserve /tmp
 
+**With [Cask](https://github.com/axetroy/cask.rs):** Just run
+
+    cask install github.com/svenstaro/miniserve
+
 ## Shell completions
 
 If you'd like to make use of the built-in shell completion support, you need to run `miniserve


### PR DESCRIPTION
install miniserve via [Cask](https://github.com/axetroy/cask.rs)

This is not just recommendations, but I want to use miniserve and simply install it.

NOTE:

Cask does not need to do any additional work, such as create a PR when releasing a new version https://github.com/Homebrew/homebrew-core/pull/97241

Just need the `Cask.toml` file in the root of the repo. that's all.

```bash
# try it out
cask install github.com/axetroy/miniserve
```

![截屏2022-03-23 00 59 33](https://user-images.githubusercontent.com/9758711/159534692-ca2891e4-fed9-4db3-9746-1146b0c19617.png)
