### PR TITLE
Do not use the route for the favicon and stylesheet

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -145,8 +145,8 @@ impl MiniserveConfig {
 
         // Generate some random routes for the favicon and css so that they are very unlikely to conflict with
         // real files.
-        let favicon_route = format!("{}/{}", route_prefix, nanoid::nanoid!(10, &ROUTE_ALPHABET));
-        let css_route = format!("{}/{}", route_prefix, nanoid::nanoid!(10, &ROUTE_ALPHABET));
+        let favicon_route = format!("/{}", nanoid::nanoid!(10, &ROUTE_ALPHABET));
+        let css_route = format!("/{}", nanoid::nanoid!(10, &ROUTE_ALPHABET));
 
         let default_color_scheme = args.color_scheme;
         let default_color_scheme_dark = args.color_scheme_dark;


### PR DESCRIPTION
In order to no leak the random generated route, we must not use it as prefix in the 404 error page.
Indeed we can just use a top-level path for these files.