### PR TITLE
Run clippy only on nightly

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -152,7 +152,7 @@ jobs:
           path: ${{ matrix.artifact_name }}
 
       ###
-      # Below this line, steps will only be ran if a tag was pushed.
+      # Below this line, steps will only be run if a tag was pushed.
       ###
 
       - name: Get tag name

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,4 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+        if: matrix.rust == 'nightly'


### PR DESCRIPTION
There's no real advantage to it running on stable as well and the current problem is that I'd like to allow a lint that's only available in nightly and so it tries to allow a lint that doesn't yet exist on stable which in turn results in an error on CI. This is annoying so we'll just fix it by only running clippy on nightly.