### PR TITLE
Add support for readme rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,6 +627,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e769b5c8c8283982a987c6e948e540254f1058d5a74b8794914d4ef5fc2a24"
 
 [[package]]
+name = "comrak"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15bf1e432b302dc6236dd0db580d182ce520bb24af82d6462e2d7a5e0a31c50d"
+dependencies = [
+ "clap 2.34.0",
+ "entities",
+ "lazy_static",
+ "memchr",
+ "pest",
+ "pest_derive",
+ "regex",
+ "shell-words",
+ "syntect",
+ "typed-arena",
+ "unicode_categories",
+ "xdg",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +763,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +801,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "entities"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
+
+[[package]]
+name = "fancy-regex"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6b8560a05112eb52f04b00e5d3790c0dd75d9d980eb8a122fb23b92a623ccf"
+dependencies = [
+ "bit-set",
+ "regex",
 ]
 
 [[package]]
@@ -1292,6 +1357,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,6 +1387,21 @@ checksum = "39a734c0493409afcd49deee13c006a04e3586b9761a03543c6272c9c51f2f5a"
 dependencies = [
  "rle-decode-fast",
 ]
+
+[[package]]
+name = "line-wrap"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
+dependencies = [
+ "safemem",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "local-channel"
@@ -1359,17 +1445,6 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-
-[[package]]
-name = "markdown"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef3aab6a1d529b112695f72beec5ee80e729cb45af58663ec902c8fac764ecdd"
-dependencies = [
- "lazy_static",
- "pipeline",
- "regex",
-]
 
 [[package]]
 name = "markup5ever"
@@ -1465,6 +1540,7 @@ dependencies = [
  "clap 3.2.16",
  "clap_complete",
  "clap_mangen",
+ "comrak",
  "futures",
  "get_if_addrs",
  "grass",
@@ -1473,7 +1549,6 @@ dependencies = [
  "httparse",
  "libflate",
  "log",
- "markdown",
  "maud",
  "mime",
  "nanoid",
@@ -1611,6 +1686,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
+name = "onig"
+version = "6.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eb3502504c9c8b06634b38bfdda86a9a8cef6277f3dec4d8b17c115110dd2a3"
+dependencies = [
+ "bitflags",
+ "lazy_static",
+ "libc",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf3fbc9b931b6c9af85d219c7943c274a6ad26cff7488a2210215edd5f49bf8"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,6 +1756,50 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69486e2b8c2d2aeb9762db7b4e00b0331156393555cff467f4163ff06821eef8"
+dependencies = [
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b13570633aff33c6d22ce47dd566b10a3b9122c2fe9d8e7501895905be532b91"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3c567e5702efdc79fb18859ea74c3eb36e14c43da7b8c1f098a4ed6514ec7a0"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb32be5ee3bbdafa8c7a18b0a8a8d962b66cfa2ceee4037f49267a50ee821fe"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha-1",
+]
 
 [[package]]
 name = "phf"
@@ -1774,10 +1915,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pipeline"
-version = "0.5.0"
+name = "pkg-config"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15b6607fa632996eb8a17c9041cb6071cb75ac057abd45dece578723ea8c7c0"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+
+[[package]]
+name = "plist"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd39bc6cdc9355ad1dc5eeedefee696bb35c34caf21768741e81826c0bbd7225"
+dependencies = [
+ "base64",
+ "indexmap",
+ "line-wrap",
+ "serde",
+ "time 0.3.11",
+ "xml-rs",
+]
 
 [[package]]
 name = "port_check"
@@ -1984,6 +2139,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom 0.2.7",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,6 +2316,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2235,6 +2407,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2255,6 +2438,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2379,6 +2568,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syntect"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b20815bbe80ee0be06e6957450a841185fcf690fe0178f14d77a05ce2caa031"
+dependencies = [
+ "bincode",
+ "bitflags",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "lazy_static",
+ "lazycell",
+ "onig",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "walkdir",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -2622,10 +2834,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-arena"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b2228007eba4120145f785df0f6c92ea538f5a3635a612ecf4e334c8c1446d"
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89570599c4fe5585de2b388aab47e99f7fa4e9238a1399f707a02e356058141c"
 
 [[package]]
 name = "unchecked-index"
@@ -2668,6 +2892,12 @@ name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "untrusted"
@@ -2947,6 +3177,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4583db5cbd4c4c0303df2d15af80f0539db703fa1c68802d4cbbd2dd0f88f6"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+
+[[package]]
 name = "xml5ever"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2956,6 +3201,15 @@ dependencies = [
  "mac",
  "markup5ever",
  "time 0.1.44",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,6 +1361,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "markdown"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef3aab6a1d529b112695f72beec5ee80e729cb45af58663ec902c8fac764ecdd"
+dependencies = [
+ "lazy_static",
+ "pipeline",
+ "regex",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1462,6 +1473,7 @@ dependencies = [
  "httparse",
  "libflate",
  "log",
+ "markdown",
  "maud",
  "mime",
  "nanoid",
@@ -1760,6 +1772,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pipeline"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d15b6607fa632996eb8a17c9041cb6071cb75ac057abd45dece578723ea8c7c0"
 
 [[package]]
 name = "port_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1930,7 +1930,7 @@ dependencies = [
  "indexmap",
  "line-wrap",
  "serde",
- "time 0.3.11",
+ "time 0.3.13",
  "xml-rs",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ thiserror = "1"
 yansi = "0.5"
 zip = { version = "0.6.2", default-features = false }
 get_if_addrs = "0.5"
-markdown = "0.3.0"
+comrak = "0.14.0"
 
 [features]
 default = ["tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,8 @@ tar = "0.4"
 thiserror = "1"
 yansi = "0.5"
 zip = { version = "0.6.2", default-features = false }
+get_if_addrs = "0.5"
+markdown = "0.3.0"
 
 [features]
 default = ["tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ tar = "0.4"
 thiserror = "1"
 yansi = "0.5"
 zip = { version = "0.6.2", default-features = false }
-get_if_addrs = "0.5"
 comrak = "0.14.0"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Some mobile browsers like Firefox on Android will offer to open the camera app w
 - Shell completions
 - Sane and secure defaults
 - TLS (for supported architectures)
+- Supports README.md rendering like on GitHub
 
 ## Usage
 
@@ -203,6 +204,9 @@ Some mobile browsers like Firefox on Android will offer to open the camera app w
 
             --random-route
                 Generate a random 6-hexdigit route
+
+            --readme
+                Enable README.md redering in directories
 
             --route-prefix <ROUTE_PREFIX>
                 Use a specific route prefix

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Some mobile browsers like Firefox on Android will offer to open the camera app w
                 Generate a random 6-hexdigit route
 
             --readme
-                Enable README.md redering in directories
+                Enable README.md rendering in directories
 
             --route-prefix <ROUTE_PREFIX>
                 Use a specific route prefix

--- a/src/args.rs
+++ b/src/args.rs
@@ -197,6 +197,10 @@ pub struct CliArgs {
     #[cfg(feature = "tls")]
     #[clap(long = "tls-key", requires = "tls-cert", value_hint = ValueHint::FilePath)]
     pub tls_key: Option<PathBuf>,
+
+    /// Enable readme redering in directories
+    #[clap(long = "readme")]
+    pub readme: bool,
 }
 
 /// Checks wether an interface is valid, i.e. it can be parsed into an IP address

--- a/src/args.rs
+++ b/src/args.rs
@@ -198,7 +198,7 @@ pub struct CliArgs {
     #[clap(long = "tls-key", requires = "tls-cert", value_hint = ValueHint::FilePath)]
     pub tls_key: Option<PathBuf>,
 
-    /// Enable README.md redering in directories
+    /// Enable README.md rendering in directories
     #[clap(long)]
     pub readme: bool,
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -198,8 +198,8 @@ pub struct CliArgs {
     #[clap(long = "tls-key", requires = "tls-cert", value_hint = ValueHint::FilePath)]
     pub tls_key: Option<PathBuf>,
 
-    /// Enable readme redering in directories
-    #[clap(long = "readme")]
+    /// Enable README.md redering in directories
+    #[clap(long)]
     pub readme: bool,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -123,6 +123,9 @@ pub struct MiniserveConfig {
     /// If enabled, display a wget command to recursively download the current directory
     pub show_wget_footer: bool,
 
+    /// If enabled, render the readme from the current directory
+    pub readme: bool,
+
     /// If set, use provided rustls config for TLS
     #[cfg(feature = "tls")]
     pub tls_rustls_config: Option<rustls::ServerConfig>,
@@ -256,6 +259,7 @@ impl MiniserveConfig {
             hide_version_footer: args.hide_version_footer,
             hide_theme_selector: args.hide_theme_selector,
             show_wget_footer: args.show_wget_footer,
+	    readme: args.readme,
             tls_rustls_config: tls_rustls_server_config,
         })
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -259,7 +259,7 @@ impl MiniserveConfig {
             hide_version_footer: args.hide_version_footer,
             hide_theme_selector: args.hide_theme_selector,
             show_wget_footer: args.show_wget_footer,
-	    readme: args.readme,
+            readme: args.readme,
             tls_rustls_config: tls_rustls_server_config,
         })
     }

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -232,7 +232,7 @@ pub fn directory_listing(
     }
 
     let mut entries: Vec<Entry> = Vec::new();
-    let mut readme: Option<String> = None;
+    let mut readme: Option<PathBuf> = None;
 
     for entry in dir.path.read_dir()? {
         if dir.is_visible(&entry) || conf.show_hidden {
@@ -285,7 +285,11 @@ pub fn directory_listing(
                     ));
 		    // TODO: Pattern match?
 		    if conf.readme && file_name.to_lowercase() == "readme.md"{
-			readme = Some(file_name);
+			let file_path = conf.path.canonicalize().unwrap()
+			    .join(base.as_os_str().to_str().unwrap()
+				  .strip_prefix("/").unwrap())
+			    .join(&file_name);
+			readme = Some(file_path);
 		    }
                 }
             } else {

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -283,14 +283,22 @@ pub fn directory_listing(
                         last_modification_date,
                         symlink_dest,
                     ));
-		    // TODO: Pattern match?
-		    if conf.readme && file_name.to_lowercase() == "readme.md"{
-			let file_path = conf.path.canonicalize().unwrap()
-			    .join(base.as_os_str().to_str().unwrap()
-				  .strip_prefix("/").unwrap())
-			    .join(&file_name);
-			readme = Some(file_path);
-		    }
+                    // TODO: Pattern match?
+                    if conf.readme && file_name.to_lowercase() == "readme.md" {
+                        let file_path = conf
+                            .path
+                            .canonicalize()
+                            .unwrap()
+                            .join(
+                                base.as_os_str()
+                                    .to_str()
+                                    .unwrap()
+                                    .strip_prefix('/')
+                                    .unwrap(),
+                            )
+                            .join(&file_name);
+                        readme = Some(file_path);
+                    }
                 }
             } else {
                 continue;
@@ -381,7 +389,7 @@ pub fn directory_listing(
             HttpResponse::Ok().content_type(mime::TEXT_HTML_UTF_8).body(
                 renderer::page(
                     entries,
-		    readme,
+                    readme,
                     is_root,
                     query_params,
                     breadcrumbs,

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -232,6 +232,7 @@ pub fn directory_listing(
     }
 
     let mut entries: Vec<Entry> = Vec::new();
+    let mut readme: Option<String> = None;
 
     for entry in dir.path.read_dir()? {
         if dir.is_visible(&entry) || conf.show_hidden {
@@ -275,13 +276,17 @@ pub fn directory_listing(
                     ));
                 } else if metadata.is_file() {
                     entries.push(Entry::new(
-                        file_name,
+                        file_name.clone(),
                         EntryType::File,
                         file_url,
                         Some(ByteSize::b(metadata.len())),
                         last_modification_date,
                         symlink_dest,
                     ));
+		    // TODO: Pattern match, or user arg for readme name?
+		    if file_name.to_lowercase() == "readme.md"{
+			readme = Some(file_name);
+		    }
                 }
             } else {
                 continue;
@@ -372,6 +377,7 @@ pub fn directory_listing(
             HttpResponse::Ok().content_type(mime::TEXT_HTML_UTF_8).body(
                 renderer::page(
                     entries,
+		    readme,
                     is_root,
                     query_params,
                     breadcrumbs,

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -283,8 +283,8 @@ pub fn directory_listing(
                         last_modification_date,
                         symlink_dest,
                     ));
-		    // TODO: Pattern match, or user arg for readme name?
-		    if file_name.to_lowercase() == "readme.md"{
+		    // TODO: Pattern match?
+		    if conf.readme && file_name.to_lowercase() == "readme.md"{
 			readme = Some(file_name);
 		    }
                 }

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -7,6 +7,7 @@ use actix_web::dev::ServiceResponse;
 use actix_web::web::Query;
 use actix_web::{HttpMessage, HttpRequest, HttpResponse};
 use bytesize::ByteSize;
+use comrak::{markdown_to_html, ComrakOptions};
 use percent_encoding::{percent_decode_str, utf8_percent_encode};
 use qrcodegen::{QrCode, QrCodeEcc};
 use serde::Deserialize;
@@ -146,6 +147,50 @@ impl Breadcrumb {
     }
 }
 
+/// Readme file information
+pub struct Readme {
+    pub render: bool,
+    pub path: Option<PathBuf>,
+    pub filename: Option<String>,
+    pub contents: Option<String>,
+}
+
+impl Readme {
+    fn blank() -> Self {
+        Readme {
+            render: false,
+            path: None,
+            filename: None,
+            contents: None,
+        }
+    }
+
+    fn new(root: PathBuf, base: &Path, filename: String) -> Self {
+        let file_path = root
+            .canonicalize()
+            .unwrap()
+            .join(
+                base.as_os_str()
+                    .to_str()
+                    .unwrap()
+                    .strip_prefix('/')
+                    .unwrap(),
+            )
+            .join(&filename);
+        let contents = markdown_to_html(
+            &std::fs::read_to_string(&file_path)
+                .unwrap_or_else(|_| "Cannot read File.".to_string()),
+            &ComrakOptions::default(),
+        );
+        Readme {
+            render: true,
+            path: Some(file_path),
+            filename: Some(filename),
+            contents: Some(contents),
+        }
+    }
+}
+
 pub async fn file_handler(req: HttpRequest) -> actix_web::Result<actix_files::NamedFile> {
     let path = &req.app_data::<crate::MiniserveConfig>().unwrap().path;
     actix_files::NamedFile::open(path).map_err(Into::into)
@@ -232,7 +277,7 @@ pub fn directory_listing(
     }
 
     let mut entries: Vec<Entry> = Vec::new();
-    let mut readme: Option<PathBuf> = None;
+    let mut readme = Readme::blank();
 
     for entry in dir.path.read_dir()? {
         if dir.is_visible(&entry) || conf.show_hidden {
@@ -284,19 +329,7 @@ pub fn directory_listing(
                         symlink_dest,
                     ));
                     if conf.readme && file_name.to_lowercase() == "readme.md" {
-                        let file_path = conf
-                            .path
-                            .canonicalize()
-                            .unwrap()
-                            .join(
-                                base.as_os_str()
-                                    .to_str()
-                                    .unwrap()
-                                    .strip_prefix('/')
-                                    .unwrap(),
-                            )
-                            .join(&file_name);
-                        readme = Some(file_path);
+                        readme = Readme::new(conf.path.clone(), base, file_name)
                     }
                 }
             } else {

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -149,22 +149,12 @@ impl Breadcrumb {
 
 /// Readme file information
 pub struct Readme {
-    pub render: bool,
-    pub path: Option<PathBuf>,
-    pub filename: Option<String>,
-    pub contents: Option<String>,
+    pub path: PathBuf,
+    pub filename: String,
+    pub contents: String,
 }
 
 impl Readme {
-    fn blank() -> Self {
-        Readme {
-            render: false,
-            path: None,
-            filename: None,
-            contents: None,
-        }
-    }
-
     fn new(root: PathBuf, base: &Path, filename: String) -> Self {
         let file_path = root
             .canonicalize()
@@ -183,10 +173,9 @@ impl Readme {
             &ComrakOptions::default(),
         );
         Readme {
-            render: true,
-            path: Some(file_path),
-            filename: Some(filename),
-            contents: Some(contents),
+            path: file_path,
+            filename,
+            contents,
         }
     }
 }
@@ -277,7 +266,7 @@ pub fn directory_listing(
     }
 
     let mut entries: Vec<Entry> = Vec::new();
-    let mut readme = Readme::blank();
+    let mut readme: Option<Readme> = None;
 
     for entry in dir.path.read_dir()? {
         if dir.is_visible(&entry) || conf.show_hidden {
@@ -329,7 +318,7 @@ pub fn directory_listing(
                         symlink_dest,
                     ));
                     if conf.readme && file_name.to_lowercase() == "readme.md" {
-                        readme = Readme::new(conf.path.clone(), base, file_name)
+                        readme = Some(Readme::new(conf.path.clone(), base, file_name));
                     }
                 }
             } else {

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -283,7 +283,6 @@ pub fn directory_listing(
                         last_modification_date,
                         symlink_dest,
                     ));
-                    // TODO: Pattern match?
                     if conf.readme && file_name.to_lowercase() == "readme.md" {
                         let file_path = conf
                             .path

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -5,6 +5,7 @@ use clap::{crate_name, crate_version};
 use maud::{html, Markup, PreEscaped, DOCTYPE};
 use std::time::SystemTime;
 use strum::IntoEnumIterator;
+use std::path::Path;
 
 use crate::auth::CurrentUser;
 use crate::listing::{Breadcrumb, Entry, QueryParameters, SortingMethod, SortingOrder};
@@ -13,6 +14,7 @@ use crate::{archive::ArchiveMethod, MiniserveConfig};
 /// Renders the file listing
 pub fn page(
     entries: Vec<Entry>,
+    readme: Option<String>,
     is_root: bool,
     query_params: QueryParameters,
     breadcrumbs: Vec<Breadcrumb>,
@@ -165,6 +167,13 @@ pub fn page(
                             }
                         }
                     }
+		    @if readme.is_some() {
+			div {
+			    h3 { (readme.as_ref().unwrap()) }
+			    (PreEscaped
+			     (markdown::file_to_html(Path::new(&readme.unwrap())).unwrap()));
+			}
+		    }
                     a.back href="#top" {
                         (arrow_up())
                     }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -14,7 +14,7 @@ use crate::{archive::ArchiveMethod, MiniserveConfig};
 /// Renders the file listing
 pub fn page(
     entries: Vec<Entry>,
-    readme: Readme,
+    readme: Option<Readme>,
     is_root: bool,
     query_params: QueryParameters,
     breadcrumbs: Vec<Breadcrumb>,
@@ -167,10 +167,10 @@ pub fn page(
                             }
                         }
                     }
-            @if readme.render {
+            @if readme.is_some() {
                 div {
-                    h3 { (readme.filename.unwrap()) }
-                    (PreEscaped (readme.contents.unwrap()));
+                    h3 { (readme.as_ref().unwrap().filename) }
+                    (PreEscaped (readme.unwrap().contents));
                 }
             }
                     a.back href="#top" {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -2,21 +2,19 @@ use actix_web::http::StatusCode;
 use chrono::{DateTime, Utc};
 use chrono_humanize::Humanize;
 use clap::{crate_name, crate_version};
-use comrak::{markdown_to_html, ComrakOptions};
 use maud::{html, Markup, PreEscaped, DOCTYPE};
-use std::path::PathBuf;
 use std::time::SystemTime;
 use strum::IntoEnumIterator;
 
 use crate::auth::CurrentUser;
-use crate::listing::{Breadcrumb, Entry, QueryParameters, SortingMethod, SortingOrder};
+use crate::listing::{Breadcrumb, Entry, QueryParameters, Readme, SortingMethod, SortingOrder};
 use crate::{archive::ArchiveMethod, MiniserveConfig};
 
 #[allow(clippy::too_many_arguments)]
 /// Renders the file listing
 pub fn page(
     entries: Vec<Entry>,
-    readme: Option<PathBuf>,
+    readme: Readme,
     is_root: bool,
     query_params: QueryParameters,
     breadcrumbs: Vec<Breadcrumb>,
@@ -169,15 +167,10 @@ pub fn page(
                             }
                         }
                     }
-            @if readme.is_some() {
+            @if readme.render {
                 div {
-                    h3 { (readme.as_ref().unwrap().file_name().unwrap()
-                          .to_string_lossy().to_string()) }
-                    (PreEscaped
-                     (markdown_to_html(
-                         &std::fs::read_to_string(readme.unwrap())
-                             .unwrap_or_else(|_| "Cannot read File.".to_string()),
-                         &ComrakOptions::default())));
+                    h3 { (readme.filename.unwrap()) }
+                    (PreEscaped (readme.contents.unwrap()));
                 }
             }
                     a.back href="#top" {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -2,11 +2,11 @@ use actix_web::http::StatusCode;
 use chrono::{DateTime, Utc};
 use chrono_humanize::Humanize;
 use clap::{crate_name, crate_version};
+use comrak::{markdown_to_html, ComrakOptions};
 use maud::{html, Markup, PreEscaped, DOCTYPE};
 use std::path::PathBuf;
 use std::time::SystemTime;
 use strum::IntoEnumIterator;
-use comrak::{markdown_to_html, ComrakOptions};
 
 use crate::auth::CurrentUser;
 use crate::listing::{Breadcrumb, Entry, QueryParameters, SortingMethod, SortingOrder};
@@ -168,17 +168,17 @@ pub fn page(
                             }
                         }
                     }
-		    @if readme.is_some() {
-			div {
-			    h3 { (readme.as_ref().unwrap().file_name().unwrap()
-				  .to_string_lossy().to_string()) }
-			    (PreEscaped
-			     (markdown_to_html(
-				 &std::fs::read_to_string(readme.unwrap())
-				     .unwrap_or_else(|_| "Cannot read File.".to_string()),
-				 &ComrakOptions::default())));
-			}
-		    }
+            @if readme.is_some() {
+            div {
+                h3 { (readme.as_ref().unwrap().file_name().unwrap()
+                  .to_string_lossy().to_string()) }
+                (PreEscaped
+                 (markdown_to_html(
+                 &std::fs::read_to_string(readme.unwrap())
+                     .unwrap_or_else(|_| "Cannot read File.".to_string()),
+                 &ComrakOptions::default())));
+            }
+            }
                     a.back href="#top" {
                         (arrow_up())
                     }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -12,6 +12,7 @@ use crate::auth::CurrentUser;
 use crate::listing::{Breadcrumb, Entry, QueryParameters, SortingMethod, SortingOrder};
 use crate::{archive::ArchiveMethod, MiniserveConfig};
 
+#[allow(clippy::too_many_arguments)]
 /// Renders the file listing
 pub fn page(
     entries: Vec<Entry>,
@@ -169,15 +170,15 @@ pub fn page(
                         }
                     }
             @if readme.is_some() {
-            div {
-                h3 { (readme.as_ref().unwrap().file_name().unwrap()
-                  .to_string_lossy().to_string()) }
-                (PreEscaped
-                 (markdown_to_html(
-                 &std::fs::read_to_string(readme.unwrap())
-                     .unwrap_or_else(|_| "Cannot read File.".to_string()),
-                 &ComrakOptions::default())));
-            }
+                div {
+                    h3 { (readme.as_ref().unwrap().file_name().unwrap()
+                          .to_string_lossy().to_string()) }
+                    (PreEscaped
+                     (markdown_to_html(
+                         &std::fs::read_to_string(readme.unwrap())
+                             .unwrap_or_else(|_| "Cannot read File.".to_string()),
+                         &ComrakOptions::default())));
+                }
             }
                     a.back href="#top" {
                         (arrow_up())


### PR DESCRIPTION
Fixes https://github.com/svenstaro/miniserve/issues/859

Suggestions are welcome, I'm only implemented the basic render for now.

Other things that might be needed:
- user flag to turn on/off readme rendering
- render html bits inside markdown (might to be fixed from `markdown` crate)
- other formats besides `.md` (`.txt` and , maybe `.org`)