### PR TITLE
Add tests for `--readme`

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -168,9 +168,11 @@ pub fn page(
                         }
                     }
                     @if let Some(readme) = readme {
-                        div {
-                            h3 { (readme.0) }
-                            (PreEscaped (readme.1));
+                        div id="readme" {
+                            h3 id="readme-filename" { (readme.0) }
+                            div id="readme-contents" {
+                                (PreEscaped (readme.1))
+                            };
                         }
                     }
                     a.back href="#top" {

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -17,7 +17,6 @@ pub static FILES: &[&str] = &[
     "test.txt",
     "test.html",
     "test.mkv",
-    "readme.md",
     #[cfg(not(windows))]
     "test \" \' & < >.csv",
     "😀.data",

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -17,6 +17,7 @@ pub static FILES: &[&str] = &[
     "test.txt",
     "test.html",
     "test.mkv",
+    "readme.md",
     #[cfg(not(windows))]
     "test \" \' & < >.csv",
     "😀.data",

--- a/tests/readme.rs
+++ b/tests/readme.rs
@@ -6,6 +6,7 @@ use select::predicate::Attr;
 use select::{document::Document, node::Node};
 use std::fs::{remove_file, File};
 use std::io::Write;
+use std::path::PathBuf;
 
 #[rstest]
 /// Do not show readme contents by default
@@ -33,49 +34,85 @@ fn no_readme_contents(server: TestServer) -> Result<(), Error> {
     case("README.MD"),
     case("ReAdMe.Md")
 )]
-/// Show readme contents when told to if there is readme.md/README.md file
-fn show_readme_contents(
+
+/// Show readme contents when told to if there is readme.md/README.md file in root
+fn show_root_readme_contents(
+    #[with(&["--readme"])] server: TestServer,
+    readme_name: &str,
+) -> Result<(), Error> {
+    let readme_path = write_readme_contents(server.path().to_path_buf(), readme_name);
+    let body = reqwest::blocking::get(server.url())?.error_for_status()?;
+    let parsed = Document::from_read(body)?;
+
+    for &file in FILES {
+        assert!(parsed.find(|x: &Node| x.text() == file).next().is_some());
+    }
+    assert_readme_contents(&parsed, &readme_name);
+    remove_file(readme_path).unwrap();
+    Ok(())
+}
+
+#[rstest(
+    readme_name,
+    case("Readme.md"),
+    case("readme.md"),
+    case("README.md"),
+    case("README.MD"),
+    case("ReAdMe.Md")
+)]
+/// Show readme contents when told to if there is readme.md/README.md file in directories
+fn show_nested_readme_contents(
     #[with(&["--readme"])] server: TestServer,
     readme_name: &str,
 ) -> Result<(), Error> {
     for dir in DIRECTORIES {
-        let readme_path = server.path().join(dir).join(readme_name);
-        let mut readme_file = File::create(&readme_path)?;
-        readme_file
-            .write(
-                format!("Contents of {}", readme_name)
-                    .to_string()
-                    .as_bytes(),
-            )
-            .expect("Couldn't write readme");
+        let readme_path = write_readme_contents(server.path().join(dir), readme_name);
         let body = reqwest::blocking::get(server.url().join(dir)?)?.error_for_status()?;
         let parsed = Document::from_read(body)?;
 
         for &file in FILES {
             assert!(parsed.find(|x: &Node| x.text() == file).next().is_some());
         }
-
-        assert!(parsed.find(Attr("id", "readme")).next().is_some());
-        assert!(parsed.find(Attr("id", "readme-filename")).next().is_some());
-        assert!(
-            parsed
-                .find(Attr("id", "readme-filename"))
-                .next()
-                .unwrap()
-                .text()
-                == readme_name
-        );
-        assert!(parsed.find(Attr("id", "readme-contents")).next().is_some());
-        assert!(
-            parsed
-                .find(Attr("id", "readme-contents"))
-                .next()
-                .unwrap()
-                .text()
-                .trim()
-                == format!("Contents of {}", readme_name)
-        );
+        assert_readme_contents(&parsed, &readme_name);
         remove_file(readme_path).unwrap();
     }
     Ok(())
+}
+
+fn write_readme_contents(path: PathBuf, filename: &str) -> PathBuf {
+    let readme_path = path.join(filename);
+    let mut readme_file = File::create(&readme_path).unwrap();
+    readme_file
+        .write(format!("Contents of {}", filename).to_string().as_bytes())
+        .expect("Couldn't write readme");
+    readme_path
+}
+
+fn assert_readme_contents(parsed_dom: &Document, filename: &str) {
+    assert!(parsed_dom.find(Attr("id", "readme")).next().is_some());
+    assert!(parsed_dom
+        .find(Attr("id", "readme-filename"))
+        .next()
+        .is_some());
+    assert!(
+        parsed_dom
+            .find(Attr("id", "readme-filename"))
+            .next()
+            .unwrap()
+            .text()
+            == filename
+    );
+    assert!(parsed_dom
+        .find(Attr("id", "readme-contents"))
+        .next()
+        .is_some());
+    assert!(
+        parsed_dom
+            .find(Attr("id", "readme-contents"))
+            .next()
+            .unwrap()
+            .text()
+            .trim()
+            == format!("Contents of {}", filename)
+    );
 }

--- a/tests/readme.rs
+++ b/tests/readme.rs
@@ -1,16 +1,9 @@
 mod fixtures;
 
-use assert_cmd::prelude::*;
-use assert_fs::fixture::{FileWriteStr, TempDir};
-use assert_fs::prelude::PathChild;
-use fixtures::{server, tmpdir, Error, TestServer, DIRECTORIES};
-use reqwest::Url;
+use fixtures::{server, Error, TestServer, DIRECTORIES};
 use rstest::rstest;
 use select::document::Document;
 use select::predicate::Attr;
-use std::process::{Command, Stdio};
-use std::thread::sleep;
-use std::time::Duration;
 
 #[rstest]
 /// Do not show readme contents by default
@@ -26,21 +19,8 @@ fn no_readme_contents(server: TestServer) -> Result<(), Error> {
 
 #[rstest]
 /// Show readme contents when told to if there is readme.md file
-fn show_readme_contents(tmpdir: TempDir) -> Result<(), Error> {
-    tmpdir
-        .child("readme.md")
-        .write_str("Readme Contents.")
-        .expect("Couldn't write to readme.md");
-    let mut child = Command::cargo_bin("miniserve")?
-        .arg("--readme")
-        .arg("--port")
-        .arg("8090")
-        .arg(tmpdir.path())
-        .stdout(Stdio::null())
-        .spawn()?;
-
-    sleep(Duration::from_secs(1));
-    let body = reqwest::blocking::get("http://localhost:8090")?.error_for_status()?;
+fn show_readme_contents(#[with(&["--readme"])] server: TestServer) -> Result<(), Error> {
+    let body = reqwest::blocking::get(server.url())?.error_for_status()?;
     let parsed = Document::from_read(body)?;
     assert!(parsed.find(Attr("id", "readme")).next().is_some());
     assert!(parsed.find(Attr("id", "readme-filename")).next().is_some());
@@ -60,35 +40,20 @@ fn show_readme_contents(tmpdir: TempDir) -> Result<(), Error> {
             .unwrap()
             .text()
             .trim()
-            == "Readme Contents."
+            == "Test Hello Yes"
     );
 
-    child.kill()?;
     Ok(())
 }
 
 #[rstest]
 /// Show readme contents when told to if there is readme.md file on directories.
-fn show_readme_contents_directories(tmpdir: TempDir) -> Result<(), Error> {
+fn show_readme_contents_directories(#[with(&["--readme"])] server: TestServer) -> Result<(), Error> {
     let directories = DIRECTORIES.to_vec();
-    for directory in directories.iter() {
-        tmpdir
-            .child(format!("{}{}", directory, "readme.md"))
-            .write_str(&format!("Readme Contents for {}.", directory))
-            .expect("Couldn't write to file");
-    }
-
-    let mut child = Command::cargo_bin("miniserve")?
-        .arg("--readme")
-        .arg(tmpdir.path())
-        .stdout(Stdio::null())
-        .spawn()?;
-
-    sleep(Duration::from_secs(1));
 
     for directory in directories {
         let dir_body =
-            reqwest::blocking::get(Url::parse("http://localhost:8080")?.join(&directory)?)?
+            reqwest::blocking::get(server.url().join(&directory)?)?
                 .error_for_status()?;
         let dir_body_parsed = Document::from_read(dir_body)?;
         assert!(dir_body_parsed.find(Attr("id", "readme")).next().is_some());
@@ -115,10 +80,9 @@ fn show_readme_contents_directories(tmpdir: TempDir) -> Result<(), Error> {
                 .unwrap()
                 .text()
                 .trim()
-                == format!("Readme Contents for {}.", directory)
+                == &format!("This is {}readme.md", directory)
         );
     }
 
-    child.kill()?;
     Ok(())
 }

--- a/tests/readme.rs
+++ b/tests/readme.rs
@@ -1,15 +1,21 @@
 mod fixtures;
 
-use fixtures::{server, Error, TestServer, DIRECTORIES};
+use fixtures::{server, Error, TestServer, DIRECTORIES, FILES};
 use rstest::rstest;
-use select::document::Document;
 use select::predicate::Attr;
+use select::{document::Document, node::Node};
 
 #[rstest]
 /// Do not show readme contents by default
 fn no_readme_contents(server: TestServer) -> Result<(), Error> {
     let body = reqwest::blocking::get(server.url())?.error_for_status()?;
     let parsed = Document::from_read(body)?;
+    for &file in FILES {
+        assert!(parsed.find(|x: &Node| x.text() == file).next().is_some());
+    }
+    for &dir in DIRECTORIES {
+        assert!(parsed.find(|x: &Node| x.text() == dir).next().is_some());
+    }
     assert!(parsed.find(Attr("id", "readme")).next().is_none());
     assert!(parsed.find(Attr("id", "readme-filename")).next().is_none());
     assert!(parsed.find(Attr("id", "readme-contents")).next().is_none());
@@ -17,11 +23,26 @@ fn no_readme_contents(server: TestServer) -> Result<(), Error> {
     Ok(())
 }
 
-#[rstest]
+#[rstest(
+    dir,
+    content,
+    case("", "Test Hello Yes"),
+    case("/dira/", "This is dira/readme.md"),
+    case("/dirb/", "This is dirb/readme.md")
+)]
 /// Show readme contents when told to if there is readme.md file
-fn show_readme_contents(#[with(&["--readme"])] server: TestServer) -> Result<(), Error> {
-    let body = reqwest::blocking::get(server.url())?.error_for_status()?;
+fn show_readme_contents(
+    #[with(&["--readme"])] server: TestServer,
+    dir: &str,
+    content: &str,
+) -> Result<(), Error> {
+    let body = reqwest::blocking::get(server.url().join(dir)?)?.error_for_status()?;
     let parsed = Document::from_read(body)?;
+
+    for &file in FILES {
+        assert!(parsed.find(|x: &Node| x.text() == file).next().is_some());
+    }
+
     assert!(parsed.find(Attr("id", "readme")).next().is_some());
     assert!(parsed.find(Attr("id", "readme-filename")).next().is_some());
     assert!(
@@ -40,50 +61,8 @@ fn show_readme_contents(#[with(&["--readme"])] server: TestServer) -> Result<(),
             .unwrap()
             .text()
             .trim()
-            == "Test Hello Yes"
+            == content
     );
-
-    Ok(())
-}
-
-#[rstest]
-/// Show readme contents when told to if there is readme.md file on directories.
-fn show_readme_contents_directories(
-    #[with(&["--readme"])] server: TestServer,
-) -> Result<(), Error> {
-    let directories = DIRECTORIES.to_vec();
-
-    for directory in directories {
-        let dir_body =
-            reqwest::blocking::get(server.url().join(&directory)?)?.error_for_status()?;
-        let dir_body_parsed = Document::from_read(dir_body)?;
-        assert!(dir_body_parsed.find(Attr("id", "readme")).next().is_some());
-        assert!(dir_body_parsed
-            .find(Attr("id", "readme-filename"))
-            .next()
-            .is_some());
-        assert!(
-            dir_body_parsed
-                .find(Attr("id", "readme-filename"))
-                .next()
-                .unwrap()
-                .text()
-                == "readme.md"
-        );
-        assert!(dir_body_parsed
-            .find(Attr("id", "readme-contents"))
-            .next()
-            .is_some());
-        assert!(
-            dir_body_parsed
-                .find(Attr("id", "readme-contents"))
-                .next()
-                .unwrap()
-                .text()
-                .trim()
-                == &format!("This is {}readme.md", directory)
-        );
-    }
 
     Ok(())
 }

--- a/tests/readme.rs
+++ b/tests/readme.rs
@@ -25,7 +25,7 @@ fn no_readme_contents(server: TestServer) -> Result<(), Error> {
 }
 
 #[rstest]
-/// Show readme contents when told to if there is no readme.md file
+/// Show readme contents when told to if there is readme.md file
 fn show_readme_contents(tmpdir: TempDir) -> Result<(), Error> {
     tmpdir
         .child("readme.md")
@@ -68,13 +68,13 @@ fn show_readme_contents(tmpdir: TempDir) -> Result<(), Error> {
 }
 
 #[rstest]
-/// Show readme contents when told to if there is no readme.md file
+/// Show readme contents when told to if there is readme.md file on directories.
 fn show_readme_contents_directories(tmpdir: TempDir) -> Result<(), Error> {
     let directories = DIRECTORIES.to_vec();
     for directory in directories.iter() {
         tmpdir
             .child(format!("{}{}", directory, "readme.md"))
-            .write_str("Readme Contents.")
+            .write_str(&format!("Readme Contents for {}.", directory))
             .expect("Couldn't write to file");
     }
 
@@ -115,7 +115,7 @@ fn show_readme_contents_directories(tmpdir: TempDir) -> Result<(), Error> {
                 .unwrap()
                 .text()
                 .trim()
-                == "Readme Contents."
+                == format!("Readme Contents for {}.", directory)
         );
     }
 

--- a/tests/readme.rs
+++ b/tests/readme.rs
@@ -48,13 +48,14 @@ fn show_readme_contents(#[with(&["--readme"])] server: TestServer) -> Result<(),
 
 #[rstest]
 /// Show readme contents when told to if there is readme.md file on directories.
-fn show_readme_contents_directories(#[with(&["--readme"])] server: TestServer) -> Result<(), Error> {
+fn show_readme_contents_directories(
+    #[with(&["--readme"])] server: TestServer,
+) -> Result<(), Error> {
     let directories = DIRECTORIES.to_vec();
 
     for directory in directories {
         let dir_body =
-            reqwest::blocking::get(server.url().join(&directory)?)?
-                .error_for_status()?;
+            reqwest::blocking::get(server.url().join(&directory)?)?.error_for_status()?;
         let dir_body_parsed = Document::from_read(dir_body)?;
         assert!(dir_body_parsed.find(Attr("id", "readme")).next().is_some());
         assert!(dir_body_parsed

--- a/tests/readme.rs
+++ b/tests/readme.rs
@@ -1,0 +1,124 @@
+mod fixtures;
+
+use assert_cmd::prelude::*;
+use assert_fs::fixture::{FileWriteStr, TempDir};
+use assert_fs::prelude::PathChild;
+use fixtures::{server, tmpdir, Error, TestServer, DIRECTORIES};
+use reqwest::Url;
+use rstest::rstest;
+use select::document::Document;
+use select::predicate::Attr;
+use std::process::{Command, Stdio};
+use std::thread::sleep;
+use std::time::Duration;
+
+#[rstest]
+/// Do not show readme contents by default
+fn no_readme_contents(server: TestServer) -> Result<(), Error> {
+    let body = reqwest::blocking::get(server.url())?.error_for_status()?;
+    let parsed = Document::from_read(body)?;
+    assert!(parsed.find(Attr("id", "readme")).next().is_none());
+    assert!(parsed.find(Attr("id", "readme-filename")).next().is_none());
+    assert!(parsed.find(Attr("id", "readme-contents")).next().is_none());
+
+    Ok(())
+}
+
+#[rstest]
+/// Show readme contents when told to if there is no readme.md file
+fn show_readme_contents(tmpdir: TempDir) -> Result<(), Error> {
+    tmpdir
+        .child("readme.md")
+        .write_str("Readme Contents.")
+        .expect("Couldn't write to readme.md");
+    let mut child = Command::cargo_bin("miniserve")?
+        .arg("--readme")
+        .arg("--port")
+        .arg("8090")
+        .arg(tmpdir.path())
+        .stdout(Stdio::null())
+        .spawn()?;
+
+    sleep(Duration::from_secs(1));
+    let body = reqwest::blocking::get("http://localhost:8090")?.error_for_status()?;
+    let parsed = Document::from_read(body)?;
+    assert!(parsed.find(Attr("id", "readme")).next().is_some());
+    assert!(parsed.find(Attr("id", "readme-filename")).next().is_some());
+    assert!(
+        parsed
+            .find(Attr("id", "readme-filename"))
+            .next()
+            .unwrap()
+            .text()
+            == "readme.md"
+    );
+    assert!(parsed.find(Attr("id", "readme-contents")).next().is_some());
+    assert!(
+        parsed
+            .find(Attr("id", "readme-contents"))
+            .next()
+            .unwrap()
+            .text()
+            .trim()
+            == "Readme Contents."
+    );
+
+    child.kill()?;
+    Ok(())
+}
+
+#[rstest]
+/// Show readme contents when told to if there is no readme.md file
+fn show_readme_contents_directories(tmpdir: TempDir) -> Result<(), Error> {
+    let directories = DIRECTORIES.to_vec();
+    for directory in directories.iter() {
+        tmpdir
+            .child(format!("{}{}", directory, "readme.md"))
+            .write_str("Readme Contents.")
+            .expect("Couldn't write to file");
+    }
+
+    let mut child = Command::cargo_bin("miniserve")?
+        .arg("--readme")
+        .arg(tmpdir.path())
+        .stdout(Stdio::null())
+        .spawn()?;
+
+    sleep(Duration::from_secs(1));
+
+    for directory in directories {
+        let dir_body =
+            reqwest::blocking::get(Url::parse("http://localhost:8080")?.join(&directory)?)?
+                .error_for_status()?;
+        let dir_body_parsed = Document::from_read(dir_body)?;
+        assert!(dir_body_parsed.find(Attr("id", "readme")).next().is_some());
+        assert!(dir_body_parsed
+            .find(Attr("id", "readme-filename"))
+            .next()
+            .is_some());
+        assert!(
+            dir_body_parsed
+                .find(Attr("id", "readme-filename"))
+                .next()
+                .unwrap()
+                .text()
+                == "readme.md"
+        );
+        assert!(dir_body_parsed
+            .find(Attr("id", "readme-contents"))
+            .next()
+            .is_some());
+        assert!(
+            dir_body_parsed
+                .find(Attr("id", "readme-contents"))
+                .next()
+                .unwrap()
+                .text()
+                .trim()
+                == "Readme Contents."
+        );
+    }
+
+    child.kill()?;
+    Ok(())
+}


### PR DESCRIPTION
Fixes https://github.com/svenstaro/miniserve/issues/879

I've tried a bit here to write tests. Idk why the `child.kill()?` isn't working properly so I've made two tests in different servers. 

I also tried to add `readme.md` in `FILES` to just use the testserver, but some other tests failed when I did that.