### PR TITLE
Fix typos

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -250,7 +250,7 @@ where
                 continue;
             }
             let current_entry_name = entry_path.file_name().ok_or_else(|| {
-                ContextualError::InvalidPathError("Invalid file or direcotory name".to_string())
+                ContextualError::InvalidPathError("Invalid file or directory name".to_string())
             })?;
             if entry_metadata.is_file() {
                 let mut f = File::open(&entry_path)

--- a/src/args.rs
+++ b/src/args.rs
@@ -203,7 +203,7 @@ pub struct CliArgs {
     pub readme: bool,
 }
 
-/// Checks wether an interface is valid, i.e. it can be parsed into an IP address
+/// Checks whether an interface is valid, i.e. it can be parsed into an IP address
 fn parse_interface(src: &str) -> Result<IpAddr, std::net::AddrParseError> {
     src.parse::<IpAddr>()
 }

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -121,12 +121,12 @@ impl Entry {
         }
     }
 
-    /// Returns wether the entry is a directory
+    /// Returns whether the entry is a directory
     pub fn is_dir(&self) -> bool {
         self.entry_type == EntryType::Directory
     }
 
-    /// Returns wether the entry is a file
+    /// Returns whether the entry is a file
     pub fn is_file(&self) -> bool {
         self.entry_type == EntryType::File
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -299,7 +299,7 @@ fn configure_app(app: &mut web::ServiceConfig, conf: &MiniserveConfig) {
             if conf.spa {
                 files = files.default_handler(
                     NamedFile::open(&conf.path.join(index_file))
-                        .expect("Cant open SPA index file."),
+                        .expect("Can't open SPA index file."),
                 );
             }
         }

--- a/tests/serve_request.rs
+++ b/tests/serve_request.rs
@@ -135,7 +135,7 @@ fn serves_requests_symlinks(
     let broken = "symlink broken";
 
     // Set up some basic symlinks:
-    // to dir, to file, to non-existant location
+    // to dir, to file, to non-existent location
     let orig = DIRECTORIES[0].strip_suffix("/").unwrap();
     let link = server.path().join(dir.strip_suffix("/").unwrap());
     symlink_dir(orig, link).expect("Couldn't create symlink");
@@ -166,7 +166,7 @@ fn serves_requests_symlinks(
         }
 
         // If following symlinks is deactivated, we can just skip this iteration as we assorted
-        // above tht no entries in the listing can be found for symlinks in that case.
+        // above the no entries in the listing can be found for symlinks in that case.
         if no_symlinks {
             continue;
         }


### PR DESCRIPTION
Found via `codespell -L crate`.