### PR TITLE
Add support for README.txt and README files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ mime = "0.3"
 nanoid = "0.4"
 percent-encoding = "2"
 port_check = "0.1"
+regex = "1"
 rustls = { version = "0.20", optional = true }
 rustls-pemfile = { version = "1.0", optional = true }
 serde = { version = "1", features = ["derive"] }

--- a/tests/readme.rs
+++ b/tests/readme.rs
@@ -64,7 +64,11 @@ fn show_root_readme_contents(
     case("readme.md"),
     case("README.md"),
     case("README.MD"),
-    case("ReAdMe.Md")
+    case("ReAdMe.Md"),
+    case("Readme.txt"),
+    case("README.txt"),
+    case("README"),
+    case("ReAdMe")
 )]
 fn show_nested_readme_contents(
     #[with(&["--readme"])] server: TestServer,
@@ -113,13 +117,11 @@ fn assert_readme_contents(parsed_dom: &Document, filename: &str) {
         .find(Attr("id", "readme-contents"))
         .next()
         .is_some());
-    assert!(
-        parsed_dom
-            .find(Attr("id", "readme-contents"))
-            .next()
-            .unwrap()
-            .text()
-            .trim()
-            == format!("Contents of {}", filename)
-    );
+    assert!(parsed_dom
+        .find(Attr("id", "readme-contents"))
+        .next()
+        .unwrap()
+        .text()
+        .trim()
+        .contains(&format!("Contents of {}", filename)));
 }


### PR DESCRIPTION
Since we added support for readme.md I thought it'd be easy enough to do readme.txt and just plain readme.

I was thinking of adding support for readme.org like in GitHub but didn't find any libraries that can convert it easily.

Also, if I rename "README.md" from miniserve to .txt, it only shows a fraction of the file contents, I can't debug it... 