### PR TITLE
Use gcr.io/distroless/cc as a glibc-based container instead of ubuntu

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,3 +1,3 @@
-FROM docker.io/ubuntu
+FROM gcr.io/distroless/cc
 COPY --chmod=755 miniserve /app/
 ENTRYPOINT ["/app/miniserve"]


### PR DESCRIPTION
This should have less useless stuff in the image and fix #939.