### PR TITLE
feat/issue-306-pr 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1604,6 +1604,7 @@ dependencies = [
  "tar",
  "thiserror",
  "url",
+ "walkdir",
  "yansi",
  "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ socket2 = "0.4"
 strum = { version = "0.24", features = ["derive"] }
 tar = "0.4"
 thiserror = "1"
+walkdir = "2.3.2"
 yansi = "0.5"
 zip = { version = "0.6.2", default-features = false }
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -511,19 +511,23 @@ fn entry_row(
                         }
 
                         @if !raw {
-                            @if let Some(size) = entry.size {
-                                span.mobile-info.size {
-                                    (maud::display(size))
-                                }
+                            span.mobile-info.size {
+                                (maud::display(&entry.size))
                             }
+                            // @if let size = entry.size {
+                            //     span.mobile-info.size {
+                            //         (maud::display(size))
+                            //     }
+                            // }
                         }
                     }
                 }
             }
             td.size-cell {
-                @if let Some(size) = entry.size {
-                    (maud::display(size))
-                }
+                (maud::display(&entry.size))
+                // @if let size = entry.size {
+                //     (maud::display(size))
+                // }
             }
             td.date-cell {
                 @if let Some(modification_date) = convert_to_utc(entry.last_modification_date) {


### PR DESCRIPTION
This would resolve issue #306 with entry counts for directories. 
This also resolves issue #964 as I had to define how to compare `EntrySize::EntryCount` and `EntrySize::Bytes`.

This adds a single dependency [`walkdir`](https://docs.rs/walkdir/latest/walkdir/) to handle counting the number of items in a directory cross-platform. Also, by default it doesn't follow symbolic links which seems fine.