### PR TITLE
[fix] Sorting breaks subdir downloading

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -411,7 +411,7 @@ fn archive_button(
 
 /// Ensure that there's always a trailing slash behind the `link`.
 fn make_link_with_trailing_slash(link: &str) -> String {
-    if link.ends_with('/') {
+    if link.is_empty() || link.ends_with('/') {
         link.to_string()
     } else {
         format!("{}/", link)


### PR DESCRIPTION
Adds a small check in `render.rs` `make_link_with_trailing_slash` to do nothing if link is empty, instead of adding a slash where its not needed.

It looks like nothing calls make_link_with_trailing_slash with an empty string aside from downloading when sorting, so this should not break anything else.

You can test the fix out here if needed: https://archive.vamist.dev/


Another alternative fix is to just not include sorting options when downloading, so if you would rather this, let me know.

Fixes #967 