### PR TITLE
Set +crt-static on x86_64-pc-windows-msvc

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
Should address #1105.

Something to keep in mind: https://github.com/rust-lang/rust/issues/71651