### PR TITLE
Add ability to read auth from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Sometimes this is just a more practical and quick way than doing things properly
 
     pw=$(echo -n "123" | sha256sum | cut -f 1 -d ' ')
     miniserve --auth joe:sha256:$pw unreleased-linux-distros/
+    
+### Require username/password from file (separate logins with new lines):
+
+    miniserve --auth-file auth.txt unreleased-linux-distros/
 
 ### Generate random 6-hexdigit URL:
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -72,6 +72,10 @@ pub struct CliArgs {
     )]
     pub auth: Vec<auth::RequiredAuth>,
 
+    /// Read authentication values from a file.
+    #[arg(long, value_hint = ValueHint::FilePath, env = "MINISERVE_AUTH_FILE")]
+    pub auth_file: Option<PathBuf>,
+
     /// Use a specific route prefix
     #[arg(long = "route-prefix", env = "MINISERVE_ROUTE_PREFIX")]
     pub route_prefix: Option<String>,
@@ -241,7 +245,7 @@ fn parse_interface(src: &str) -> Result<IpAddr, std::net::AddrParseError> {
 }
 
 /// Parse authentication requirement
-fn parse_auth(src: &str) -> Result<auth::RequiredAuth, ContextualError> {
+pub fn parse_auth(src: &str) -> Result<auth::RequiredAuth, ContextualError> {
     let mut split = src.splitn(3, ':');
     let invalid_auth_format = Err(ContextualError::InvalidAuthFormat);
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -72,7 +72,7 @@ pub struct CliArgs {
     )]
     pub auth: Vec<auth::RequiredAuth>,
 
-    /// Read authentication values from a file.
+    /// Read authentication values from a file
     #[arg(long, value_hint = ValueHint::FilePath, env = "MINISERVE_AUTH_FILE")]
     pub auth_file: Option<PathBuf>,
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -72,7 +72,11 @@ pub struct CliArgs {
     )]
     pub auth: Vec<auth::RequiredAuth>,
 
-    /// Read authentication values from a file
+    /// Read authentication values from a file. Example file content:
+    ///
+    /// joe:123
+    /// bob:sha256:a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3
+    /// bill:
     #[arg(long, value_hint = ValueHint::FilePath, env = "MINISERVE_AUTH_FILE")]
     pub auth_file: Option<PathBuf>,
 

--- a/tests/auth_file.rs
+++ b/tests/auth_file.rs
@@ -1,0 +1,62 @@
+mod fixtures;
+
+use fixtures::{server, server_no_stderr, Error, FILES};
+use http::StatusCode;
+use reqwest::blocking::Client;
+use rstest::rstest;
+use select::document::Document;
+use select::predicate::Text;
+
+#[rstest(
+    cli_auth_file_arg, client_username, client_password,
+    case("tests/data/auth1.txt", "joe", "123"),
+    case("tests/data/auth1.txt", "bob", "123"),
+    case("tests/data/auth1.txt", "bill", ""),
+)]
+fn auth_file_accepts(
+    cli_auth_file_arg: &str,
+    client_username: &str,
+    client_password: &str
+) -> Result<(), Error> {
+    let server = server(&["--auth-file", cli_auth_file_arg]);
+    let client = Client::new();
+    let response = client
+        .get(server.url())
+        .basic_auth(client_username, Some(client_password))
+        .send()?;
+
+    let status_code = response.status();
+    assert_eq!(status_code, StatusCode::OK);
+
+    let body = response.error_for_status()?;
+    let parsed = Document::from_read(body)?;
+    for &file in FILES {
+        assert!(parsed.find(Text).any(|x| x.text() == file));
+    } 
+
+    Ok(())
+}
+
+#[rstest(
+    cli_auth_file_arg, client_username, client_password,
+    case("tests/data/auth1.txt", "joe", "wrongpassword"),
+    case("tests/data/auth1.txt", "bob", ""),
+    case("tests/data/auth1.txt", "nonexistentuser", "wrongpassword"),
+)]
+fn auth_file_rejects(
+    cli_auth_file_arg: &str,
+    client_username: &str,
+    client_password: &str,
+) -> Result<(), Error> {
+    let server = server_no_stderr(&["--auth-file", cli_auth_file_arg]);
+    let client = Client::new();
+    let status = client
+        .get(server.url())
+        .basic_auth(client_username, Some(client_password))
+        .send()?
+        .status();
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+    Ok(())
+}

--- a/tests/data/auth1.txt
+++ b/tests/data/auth1.txt
@@ -1,0 +1,3 @@
+joe:123
+bob:sha256:a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3
+bill:


### PR DESCRIPTION
Usage: 

```
$ miniserve --auth-file auth.txt
```

Example auth.txt content

```
joe:123
bob:sha256:a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3
bill:
```

Related issue: #980 