### PR TITLE
Encode single quote in directory path name

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -267,8 +267,9 @@ fn wget_footer(abs_path: &Uri, root_dir_name: Option<&str>, current_user: Option
         None => String::new(),
     };
 
+    let encoded_abs_path = abs_path.to_string().replace("'", "%27");
     let command =
-        format!("wget -rcnHp -R 'index.html*'{cut_dirs}{user_params} '{abs_path}?raw=true'");
+        format!("wget -rcnHp -R 'index.html*'{cut_dirs}{user_params} '{encoded_abs_path}?raw=true'");
     let click_to_copy = format!("navigator.clipboard.writeText(\"{command}\")");
 
     html! {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -268,8 +268,9 @@ fn wget_footer(abs_path: &Uri, root_dir_name: Option<&str>, current_user: Option
     };
 
     let encoded_abs_path = abs_path.to_string().replace("'", "%27");
-    let command =
-        format!("wget -rcnHp -R 'index.html*'{cut_dirs}{user_params} '{encoded_abs_path}?raw=true'");
+    let command = format!(
+        "wget -rcnHp -R 'index.html*'{cut_dirs}{user_params} '{encoded_abs_path}?raw=true'"
+    );
     let click_to_copy = format!("navigator.clipboard.writeText(\"{command}\")");
 
     html! {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -267,7 +267,7 @@ fn wget_footer(abs_path: &Uri, root_dir_name: Option<&str>, current_user: Option
         None => String::new(),
     };
 
-    let encoded_abs_path = abs_path.to_string().replace("'", "%27");
+    let encoded_abs_path = abs_path.to_string().replace('\'', "%27");
     let command = format!(
         "wget -rcnHp -R 'index.html*'{cut_dirs}{user_params} '{encoded_abs_path}?raw=true'"
     );


### PR DESCRIPTION
Well I took a stab at it. Took me a minute just to be able to read rust code, since I don't have any experience with rust. However, with just a couple line changes I did get it to work. Not sure if this is how you would have liked it to have been done though.