### PR TITLE
Add pretty urls

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -41,6 +41,14 @@ pub struct CliArgs {
     #[arg(long, requires = "index", env = "MINISERVE_SPA")]
     pub spa: bool,
 
+    /// Activate Pretty URLs mode
+    ///
+    /// This will cause the server to serve the equivalent `.html` file indicated by the path.
+    ///
+    /// `/about` will try to find `about.html` and serve it.
+    #[arg(long, env = "MINISERVE_PRETTY_URLS")]
+    pub pretty_urls: bool,
+
     /// Port to use
     #[arg(
         short = 'p',

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,6 +80,13 @@ pub struct MiniserveConfig {
     /// allow the SPA router to handle the request instead.
     pub spa: bool,
 
+    /// Activate Pretty URLs mode
+    ///
+    /// This will cause the server to serve the equivalent `.html` file indicated by the path.
+    ///
+    /// `/about` will try to find `about.html` and serve it.
+    pub pretty_urls: bool,
+
     /// Enable QR code display
     pub show_qrcode: bool,
 
@@ -250,6 +257,7 @@ impl MiniserveConfig {
             default_color_scheme_dark,
             index: args.index,
             spa: args.spa,
+            pretty_urls: args.pretty_urls,
             overwrite_files: args.overwrite_files,
             show_qrcode: args.qrcode,
             mkdir_enabled: args.mkdir_enabled,

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,8 +318,13 @@ fn configure_app(app: &mut web::ServiceConfig, conf: &MiniserveConfig) {
             }
         }
 
+        // Handle --pretty-urls options.
+        //
+        // We rewrite the request to append ".html" to the path and serve the file. If the
+        // path ends with a `/`, we remove it before appending ".html".
+        //
+        // This is done to allow for pretty URLs, e.g. "/about" instead of "/about.html".
         if conf.pretty_urls {
-            log::info!("Pretty URLs enabled.");
             files = files.default_handler(fn_service(|req: ServiceRequest| async {
                 let (req, _) = req.into_parts();
                 let conf = req

--- a/tests/serve_request.rs
+++ b/tests/serve_request.rs
@@ -268,6 +268,24 @@ fn serve_index_instead_of_404_in_spa_mode(
 }
 
 #[rstest]
+#[case(server_no_stderr(&["--pretty-urls", "--index", FILES[1]]), "/")]
+#[case(server_no_stderr(&["--pretty-urls", "--index", FILES[1]]), "test.html")]
+#[case(server_no_stderr(&["--pretty-urls", "--index", FILES[1]]), "test")]
+fn serve_file_instead_of_404_in_pretty_urls_mode(
+    #[case] server: TestServer,
+    #[case] url: &str,
+) -> Result<(), Error> {
+    let body = reqwest::blocking::get(format!("{}{}", server.url(), url))?.error_for_status()?;
+    let parsed = Document::from_read(body)?;
+    assert!(parsed
+        .find(|x: &Node| x.text() == "Test Hello Yes")
+        .next()
+        .is_some());
+
+    Ok(())
+}
+
+#[rstest]
 #[case(server(&["--route-prefix", "foobar"]))]
 #[case(server(&["--route-prefix", "/foobar/"]))]
 fn serves_requests_with_route_prefix(#[case] server: TestServer) -> Result<(), Error> {


### PR DESCRIPTION
This adds a new flag namely `--pretty-urls` that when enabled will serve the equivalent `.html` if it exists.

Very much the same approach that [`netlify`
uses](https://docs.netlify.com/site-deploys/post-processing/).

It can be quite useful when having hrefs like `/about` serve `/about.html`.