### PR TITLE
Prevent illegal request path from crashing program

### DIFF
--- a/src/listing.rs
+++ b/src/listing.rs
@@ -162,12 +162,17 @@ pub fn directory_listing(
 
     let base = Path::new(serve_path);
     let random_route_abs = format!("/{}", conf.route_prefix);
-    let abs_uri = http::Uri::builder()
-        .scheme(req.connection_info().scheme())
-        .authority(req.connection_info().host())
-        .path_and_query(req.uri().to_string())
-        .build()
-        .unwrap();
+    let abs_uri = {
+        let res = http::Uri::builder()
+            .scheme(req.connection_info().scheme())
+            .authority(req.connection_info().host())
+            .path_and_query(req.uri().to_string())
+            .build();
+        match res {
+            Ok(uri) => uri,
+            Err(err) => return Ok(ServiceResponse::from_err(err, req.clone())),
+        }
+    };
     let is_root = base.parent().is_none() || Path::new(&req.path()) == Path::new(&random_route_abs);
 
     let encoded_dir = match base.strip_prefix(random_route_abs) {


### PR DESCRIPTION
I experienced a service crash today due to a request that contains an illegal character in its path. The request seems to be a malicious vulnerability scan, but it shouldn't crash the program nonetheless. This PR makes sure this doesn't happen.

Logs:

```
Dec 06 04:07:59 HOSTNAME miniserve[1012]: thread 'actix-rt|system:0|arbiter:1' panicked at 'called `Result::unwrap()` on an `Err` value: http::Error(InvalidUri(InvalidUriChar))', /build/path/miniserve-0.24.0/src/listing.rs:171:10
```