### PR TITLE
Remove header Content-Encoding when archiving

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -2,7 +2,6 @@ use std::fs::File;
 use std::io::{Cursor, Read, Write};
 use std::path::{Path, PathBuf};
 
-use actix_web::http::header::ContentEncoding;
 use libflate::gzip::Encoder;
 use serde::Deserialize;
 use strum::{Display, EnumIter, EnumString};
@@ -43,14 +42,6 @@ impl ArchiveMethod {
             ArchiveMethod::Zip => "application/zip",
         }
         .to_string()
-    }
-
-    pub fn content_encoding(self) -> ContentEncoding {
-        match self {
-            ArchiveMethod::TarGz => ContentEncoding::Gzip,
-            ArchiveMethod::Tar => ContentEncoding::Identity,
-            ArchiveMethod::Zip => ContentEncoding::Identity,
-        }
     }
 
     pub fn is_enabled(self, tar_enabled: bool, tar_gz_enabled: bool, zip_enabled: bool) -> bool {

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -363,7 +363,6 @@ pub fn directory_listing(
             req.clone(),
             HttpResponse::Ok()
                 .content_type(archive_method.content_type())
-                .append_header(archive_method.content_encoding())
                 .append_header(("Content-Transfer-Encoding", "binary"))
                 .append_header((
                     "Content-Disposition",


### PR DESCRIPTION
Content-Encoding is a representation header which kinda means "same content, presented differently to different clients" or "encoded & decoded on-the-fly, guided by content negotiation".

In the case of downloading an archive, MDN docs explicitly says that (quoted from https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding):

> If the original media is encoded in some way (e.g. a zip file) then this
> information would not be included in the Content-Encoding header.

Thus this patch. Also fixes #1187.