### PR TITLE
Set default sorting order and method with arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,18 @@ Options:
 
           [env: MINISERVE_HIDDEN=]
 
+  -S, --default-sorting-method
+          Default sort method for file list
+
+          [env: MINISERVE_DEFAULT_SORTING_METHOD=]
+          [possible values: name, date, size]
+
+  -O, --default-sorting-order
+          Default sort order for file list
+
+          [env: MINISERVE_DEFAULT_SORTING_ORDER=]
+          [possible values: asc, desc]
+
   -c, --color-scheme <COLOR_SCHEME>
           Default color scheme
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -113,6 +113,26 @@ pub struct CliArgs {
     #[arg(short = 'H', long = "hidden", env = "MINISERVE_HIDDEN")]
     pub hidden: bool,
 
+    /// Default sorting method for file list
+    #[arg(
+        short = 'S',
+        long = "default-sorting-method",
+        default_value = "",
+        ignore_case = true,
+        env = "MINISERVE_DEFAULT_SORTING_METHOD"
+    )]
+    pub default_sorting_method: String,
+
+    /// Default sorting order for file list
+    #[arg(
+        short = 'O',
+        long = "default-sorting-order",
+        default_value = "",
+        ignore_case = true,
+        env = "MINISERVE_DEFAULT_SORTING_ORDER"
+    )]
+    pub default_sorting_order: String,
+
     /// Default color scheme
     #[arg(
         short = 'c',

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ use crate::{
     args::{parse_auth, CliArgs, MediaType},
     auth::RequiredAuth,
     file_utils::sanitize_path,
+    listing::{SortingMethod, SortingOrder},
     renderer::ThemeSlug,
 };
 
@@ -49,6 +50,12 @@ pub struct MiniserveConfig {
 
     /// Show hidden files
     pub show_hidden: bool,
+
+    /// Default sorting method
+    pub default_sorting_method: Option<SortingMethod>,
+
+    /// Default sorting order
+    pub default_sorting_order: Option<SortingOrder>,
 
     /// Route prefix; Either empty or prefixed with slash
     pub route_prefix: String,
@@ -265,6 +272,24 @@ impl MiniserveConfig {
             .transpose()?
             .unwrap_or_default();
 
+        let default_sorting_method: Option<SortingMethod> = match args
+            .default_sorting_method
+            .to_owned()
+            .parse::<SortingMethod>()
+        {
+            Ok(value) => Some(value),
+            Err(_) => None,
+        };
+
+        let default_sorting_order: Option<SortingOrder> = match args
+            .default_sorting_order
+            .to_owned()
+            .parse::<SortingOrder>()
+        {
+            Ok(value) => Some(value),
+            Err(_) => None,
+        };
+
         Ok(MiniserveConfig {
             verbose: args.verbose,
             path: args.path.unwrap_or_else(|| PathBuf::from(".")),
@@ -274,6 +299,8 @@ impl MiniserveConfig {
             path_explicitly_chosen,
             no_symlinks: args.no_symlinks,
             show_hidden: args.hidden,
+            default_sorting_method,
+            default_sorting_order,
             route_prefix,
             favicon_route,
             css_route,

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -223,7 +223,7 @@ pub fn directory_listing(
         res
     };
 
-    let query_params = extract_query_parameters(req);
+    let mut query_params = extract_query_parameters(req);
 
     let mut entries: Vec<Entry> = Vec::new();
     let mut readme: Option<(String, String)> = None;
@@ -299,6 +299,14 @@ pub fn directory_listing(
         }
     }
 
+    if query_params.sort.is_none() {
+        query_params.sort = conf.default_sorting_method
+    }
+
+    if query_params.order.is_none() {
+        query_params.order = conf.default_sorting_order
+    }
+
     match query_params.sort.unwrap_or(SortingMethod::Name) {
         SortingMethod::Name => entries.sort_by(|e1, e2| {
             alphanumeric_sort::compare_str(e1.name.to_lowercase(), e2.name.to_lowercase())
@@ -319,7 +327,7 @@ pub fn directory_listing(
         }),
     };
 
-    if let Some(SortingOrder::Descending) = query_params.order {
+    if let Some(SortingOrder::Ascending) = query_params.order {
         entries.reverse()
     }
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -459,7 +459,7 @@ fn build_link(
 ) -> Markup {
     let mut link = format!("?sort={name}&order=asc");
     let mut help = format!("Sort by {name} in ascending order");
-    let mut chevron = chevron_up();
+    let mut chevron = chevron_down();
     let mut class = "";
 
     if let Some(method) = sort_method {
@@ -469,7 +469,7 @@ fn build_link(
                 if order.to_string() == "asc" {
                     link = format!("?sort={name}&order=desc");
                     help = format!("Sort by {name} in descending order");
-                    chevron = chevron_down();
+                    chevron = chevron_up();
                 }
             }
         }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -12,3 +12,19 @@ pub fn get_link_from_text(document: &Document, text: &str) -> Option<String> {
         .next()?;
     Some(a_elem.attr("href")?.to_string())
 }
+
+/// Return the href attributes of all links that start with the specified prefix `text`.
+pub fn get_link_hrefs_from_text_with_prefix(document: &Document, text: &str) -> Vec<String> {
+    let mut vec: Vec<String> = Vec::new();
+
+    let a_elem = document.find(Name("a"));
+
+    for element in a_elem {
+        let str = element.attr("href").unwrap_or("");
+        if str.to_string().starts_with(text) {
+            vec.push(str.to_string());
+        }
+    }
+
+    return vec;
+}


### PR DESCRIPTION
My intention is to add a way to sort by `descending` `date` (or anything else) by default.

I think the best way to do this is with a command line argument but I am open to suggestions.

This is useful for anyone who wants the most recently created/edited files at the top of the list when the page first loads.

Without this change, a user would have to do an _entire whole extra single click_ to sort the files by date 😢 