### PR TITLE
Optional enable compression middleware to reduce response size  (disabled by default)

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -214,6 +214,18 @@ pub struct CliArgs {
     #[arg(short = 'z', long = "enable-zip", env = "MINISERVE_ENABLE_ZIP")]
     pub enable_zip: bool,
 
+    /// Enable compress response
+    ///
+    /// WARNING: Enabling this option may slow down transfers due to CPU overhead, so it is disabled by default.
+    ///
+    /// Only enable this option if you know that your users have slow connections or if you want to minimize your server's bandwidth usage.
+    #[arg(
+        short = 'C',
+        long = "compress-response",
+        env = "MINISERVE_COMPRESS_RESPONSE"
+    )]
+    pub compress_response: bool,
+
     /// List directories first
     #[arg(short = 'D', long = "dirs-first", env = "MINISERVE_DIRS_FIRST")]
     pub dirs_first: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -119,6 +119,9 @@ pub struct MiniserveConfig {
     /// If false, creation of zip archives is disabled
     pub zip_enabled: bool,
 
+    /// Enable  compress response
+    pub compress_response: bool,
+
     /// If enabled, directories are listed first
     pub dirs_first: bool,
 
@@ -309,6 +312,7 @@ impl MiniserveConfig {
             show_wget_footer: args.show_wget_footer,
             readme: args.readme,
             tls_rustls_config: tls_rustls_server_config,
+            compress_response: args.compress_response,
         })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,6 +202,7 @@ async fn run(miniserve_config: MiniserveConfig) -> Result<(), ContextualError> {
             .app_data(stylesheet.clone())
             .wrap_fn(errors::error_page_middleware)
             .wrap(middleware::Logger::default())
+            .wrap(middleware::Compress::default())
             .route(&inside_config.favicon_route, web::get().to(favicon))
             .route(&inside_config.css_route, web::get().to(css))
             .service(

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,7 +202,10 @@ async fn run(miniserve_config: MiniserveConfig) -> Result<(), ContextualError> {
             .app_data(stylesheet.clone())
             .wrap_fn(errors::error_page_middleware)
             .wrap(middleware::Logger::default())
-            .wrap(middleware::Compress::default())
+            .wrap(middleware::Condition::new(
+                miniserve_config.compress_response,
+                middleware::Compress::default(),
+            ))
             .route(&inside_config.favicon_route, web::get().to(favicon))
             .route(&inside_config.css_route, web::get().to(css))
             .service(


### PR DESCRIPTION
#523 
#497 

This PR adds an optional section to turn on compress response, turned off by default, and a note in the help docs about the impact of turning this on.

```
/// Enable compress response
///
/// WARNING: Enabling this option may slow down transfers due to CPU overhead, so it is disabled by default.
/// 
/// Only enable this option if you know that your users have slow connections or if you want to minimize your server's bandwidth usage.
```




