### PR TITLE
Fix inaccurate uses of `sanitize_path`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -266,9 +266,9 @@ impl MiniserveConfig {
             .map(|v| {
                 v.iter()
                     .map(|p| {
-                        sanitize_path(p, false)
+                        sanitize_path(p, args.hidden)
                             .map(|p| p.display().to_string().replace('\\', "/"))
-                            .ok_or(anyhow!("Illegal path {p:?}: upward traversal not allowed"))
+                            .ok_or(anyhow!("Illegal path {p:?}"))
                     })
                     .collect()
             })

--- a/src/file_op.rs
+++ b/src/file_op.rs
@@ -152,9 +152,10 @@ async fn handle_multipart(
         )
     })?;
 
-    let filename_path = sanitize_path(Path::new(&filename), false).ok_or_else(|| {
-        ContextualError::InvalidPathError("Invalid file name to upload".to_string())
-    })?;
+    let filename_path =
+        sanitize_path(Path::new(&filename), allow_hidden_paths).ok_or_else(|| {
+            ContextualError::InvalidPathError("Invalid file name to upload".to_string())
+        })?;
 
     // Ensure there are no illegal symlinks in the file upload path
     if !allow_symlinks {


### PR DESCRIPTION
Found this while working on #1093 (finally). So I thought I'd clean it up first.