### PR TITLE
Refactor errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - ReleaseDate
 - Add `-C/--compress-response` to enable response compression [1315](https://github.com/svenstaro/miniserve/pull/1315) (thanks @zuisong)
+- Refactor errors [#1331](https://github.com/svenstaro/miniserve/pull/1331) (thanks @cyqsimon)
 
 ## [0.26.0] - 2024-01-13
 - Properly handle read-only errors on Windows [#1310](https://github.com/svenstaro/miniserve/pull/1310) (thanks @ViRb3)

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -8,7 +8,7 @@ use strum::{Display, EnumIter, EnumString};
 use tar::Builder;
 use zip::{write, ZipWriter};
 
-use crate::errors::ContextualError;
+use crate::errors::RuntimeError;
 
 /// Available archive methods
 #[derive(Deserialize, Clone, Copy, EnumIter, EnumString, Display)]
@@ -62,7 +62,7 @@ impl ArchiveMethod {
         dir: T,
         skip_symlinks: bool,
         out: W,
-    ) -> Result<(), ContextualError>
+    ) -> Result<(), RuntimeError>
     where
         T: AsRef<Path>,
         W: std::io::Write,
@@ -77,17 +77,17 @@ impl ArchiveMethod {
 }
 
 /// Write a gzipped tarball of `dir` in `out`.
-fn tar_gz<W>(dir: &Path, skip_symlinks: bool, out: W) -> Result<(), ContextualError>
+fn tar_gz<W>(dir: &Path, skip_symlinks: bool, out: W) -> Result<(), RuntimeError>
 where
     W: std::io::Write,
 {
-    let mut out = Encoder::new(out).map_err(|e| ContextualError::IoError("GZIP".to_string(), e))?;
+    let mut out = Encoder::new(out).map_err(|e| RuntimeError::IoError("GZIP".to_string(), e))?;
 
     tar_dir(dir, skip_symlinks, &mut out)?;
 
     out.finish()
         .into_result()
-        .map_err(|e| ContextualError::IoError("GZIP finish".to_string(), e))?;
+        .map_err(|e| RuntimeError::IoError("GZIP finish".to_string(), e))?;
 
     Ok(())
 }
@@ -115,22 +115,22 @@ where
 /// ├── f
 /// └── g
 /// ```
-fn tar_dir<W>(dir: &Path, skip_symlinks: bool, out: W) -> Result<(), ContextualError>
+fn tar_dir<W>(dir: &Path, skip_symlinks: bool, out: W) -> Result<(), RuntimeError>
 where
     W: std::io::Write,
 {
     let inner_folder = dir.file_name().ok_or_else(|| {
-        ContextualError::InvalidPathError("Directory name terminates in \"..\"".to_string())
+        RuntimeError::InvalidPathError("Directory name terminates in \"..\"".to_string())
     })?;
 
     let directory = inner_folder.to_str().ok_or_else(|| {
-        ContextualError::InvalidPathError(
+        RuntimeError::InvalidPathError(
             "Directory name contains invalid UTF-8 characters".to_string(),
         )
     })?;
 
     tar(dir, directory.to_string(), skip_symlinks, out)
-        .map_err(|e| ContextualError::ArchiveCreationError("tarball".to_string(), Box::new(e)))
+        .map_err(|e| RuntimeError::ArchiveCreationError("tarball".to_string(), Box::new(e)))
 }
 
 /// Writes a tarball of `dir` in `out`.
@@ -141,7 +141,7 @@ fn tar<W>(
     inner_folder: String,
     skip_symlinks: bool,
     out: W,
-) -> Result<(), ContextualError>
+) -> Result<(), RuntimeError>
 where
     W: std::io::Write,
 {
@@ -153,7 +153,7 @@ where
     tar_builder
         .append_dir_all(inner_folder, src_dir)
         .map_err(|e| {
-            ContextualError::IoError(
+            RuntimeError::IoError(
                 format!(
                     "Failed to append the content of {} to the TAR archive",
                     src_dir.to_str().unwrap_or("file")
@@ -164,7 +164,7 @@ where
 
     // Finish the archive
     tar_builder.into_inner().map_err(|e| {
-        ContextualError::IoError("Failed to finish writing the TAR archive".to_string(), e)
+        RuntimeError::IoError("Failed to finish writing the TAR archive".to_string(), e)
     })?;
 
     Ok(())
@@ -197,28 +197,28 @@ fn create_zip_from_directory<W>(
     out: W,
     directory: &Path,
     skip_symlinks: bool,
-) -> Result<(), ContextualError>
+) -> Result<(), RuntimeError>
 where
     W: std::io::Write + std::io::Seek,
 {
     let options = write::FileOptions::default().compression_method(zip::CompressionMethod::Stored);
     let mut paths_queue: Vec<PathBuf> = vec![directory.to_path_buf()];
     let zip_root_folder_name = directory.file_name().ok_or_else(|| {
-        ContextualError::InvalidPathError("Directory name terminates in \"..\"".to_string())
+        RuntimeError::InvalidPathError("Directory name terminates in \"..\"".to_string())
     })?;
 
     let mut zip_writer = ZipWriter::new(out);
     let mut buffer = Vec::new();
     while !paths_queue.is_empty() {
         let next = paths_queue.pop().ok_or_else(|| {
-            ContextualError::ArchiveCreationDetailError("Could not get path from queue".to_string())
+            RuntimeError::ArchiveCreationDetailError("Could not get path from queue".to_string())
         })?;
         let current_dir = next.as_path();
         let directory_entry_iterator = std::fs::read_dir(current_dir)
-            .map_err(|e| ContextualError::IoError("Could not read directory".to_string(), e))?;
+            .map_err(|e| RuntimeError::IoError("Could not read directory".to_string(), e))?;
         let zip_directory = Path::new(zip_root_folder_name).join(
             current_dir.strip_prefix(directory).map_err(|_| {
-                ContextualError::ArchiveCreationDetailError(
+                RuntimeError::ArchiveCreationDetailError(
                     "Could not append base directory".to_string(),
                 )
             })?,
@@ -228,37 +228,36 @@ where
             let entry_path = entry
                 .ok()
                 .ok_or_else(|| {
-                    ContextualError::InvalidPathError(
+                    RuntimeError::InvalidPathError(
                         "Directory name terminates in \"..\"".to_string(),
                     )
                 })?
                 .path();
-            let entry_metadata = std::fs::metadata(entry_path.clone()).map_err(|e| {
-                ContextualError::IoError("Could not get file metadata".to_string(), e)
-            })?;
+            let entry_metadata = std::fs::metadata(entry_path.clone())
+                .map_err(|e| RuntimeError::IoError("Could not get file metadata".to_string(), e))?;
 
             if entry_metadata.file_type().is_symlink() && skip_symlinks {
                 continue;
             }
             let current_entry_name = entry_path.file_name().ok_or_else(|| {
-                ContextualError::InvalidPathError("Invalid file or directory name".to_string())
+                RuntimeError::InvalidPathError("Invalid file or directory name".to_string())
             })?;
             if entry_metadata.is_file() {
                 let mut f = File::open(&entry_path)
-                    .map_err(|e| ContextualError::IoError("Could not open file".to_string(), e))?;
+                    .map_err(|e| RuntimeError::IoError("Could not open file".to_string(), e))?;
                 f.read_to_end(&mut buffer).map_err(|e| {
-                    ContextualError::IoError("Could not read from file".to_string(), e)
+                    RuntimeError::IoError("Could not read from file".to_string(), e)
                 })?;
                 let relative_path = zip_directory.join(current_entry_name).into_os_string();
                 zip_writer
                     .start_file(relative_path.to_string_lossy(), options)
                     .map_err(|_| {
-                        ContextualError::ArchiveCreationDetailError(
+                        RuntimeError::ArchiveCreationDetailError(
                             "Could not add file path to ZIP".to_string(),
                         )
                     })?;
                 zip_writer.write(buffer.as_ref()).map_err(|_| {
-                    ContextualError::ArchiveCreationDetailError(
+                    RuntimeError::ArchiveCreationDetailError(
                         "Could not write file to ZIP".to_string(),
                     )
                 })?;
@@ -268,7 +267,7 @@ where
                 zip_writer
                     .add_directory(relative_path.to_string_lossy(), options)
                     .map_err(|_| {
-                        ContextualError::ArchiveCreationDetailError(
+                        RuntimeError::ArchiveCreationDetailError(
                             "Could not add directory path to ZIP".to_string(),
                         )
                     })?;
@@ -278,9 +277,7 @@ where
     }
 
     zip_writer.finish().map_err(|_| {
-        ContextualError::ArchiveCreationDetailError(
-            "Could not finish writing ZIP archive".to_string(),
-        )
+        RuntimeError::ArchiveCreationDetailError("Could not finish writing ZIP archive".to_string())
     })?;
     Ok(())
 }
@@ -288,39 +285,39 @@ where
 /// Writes a zip of `dir` in `out`.
 ///
 /// The content of `src_dir` will be saved in the archive as the  folder named .
-fn zip_data<W>(src_dir: &Path, skip_symlinks: bool, mut out: W) -> Result<(), ContextualError>
+fn zip_data<W>(src_dir: &Path, skip_symlinks: bool, mut out: W) -> Result<(), RuntimeError>
 where
     W: std::io::Write,
 {
     let mut data = Vec::new();
     let memory_file = Cursor::new(&mut data);
     create_zip_from_directory(memory_file, src_dir, skip_symlinks).map_err(|e| {
-        ContextualError::ArchiveCreationError(
+        RuntimeError::ArchiveCreationError(
             "Failed to create the ZIP archive".to_string(),
             Box::new(e),
         )
     })?;
 
     out.write_all(data.as_mut_slice())
-        .map_err(|e| ContextualError::IoError("Failed to write the ZIP archive".to_string(), e))?;
+        .map_err(|e| RuntimeError::IoError("Failed to write the ZIP archive".to_string(), e))?;
 
     Ok(())
 }
 
-fn zip_dir<W>(dir: &Path, skip_symlinks: bool, out: W) -> Result<(), ContextualError>
+fn zip_dir<W>(dir: &Path, skip_symlinks: bool, out: W) -> Result<(), RuntimeError>
 where
     W: std::io::Write,
 {
     let inner_folder = dir.file_name().ok_or_else(|| {
-        ContextualError::InvalidPathError("Directory name terminates in \"..\"".to_string())
+        RuntimeError::InvalidPathError("Directory name terminates in \"..\"".to_string())
     })?;
 
     inner_folder.to_str().ok_or_else(|| {
-        ContextualError::InvalidPathError(
+        RuntimeError::InvalidPathError(
             "Directory name contains invalid UTF-8 characters".to_string(),
         )
     })?;
 
     zip_data(dir, skip_symlinks, out)
-        .map_err(|e| ContextualError::ArchiveCreationError("zip".to_string(), Box::new(e)))
+        .map_err(|e| RuntimeError::ArchiveCreationError("zip".to_string(), Box::new(e)))
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -2,7 +2,7 @@ use actix_web::{dev::ServiceRequest, HttpMessage};
 use actix_web_httpauth::extractors::basic::BasicAuth;
 use sha2::{Digest, Sha256, Sha512};
 
-use crate::errors::ContextualError;
+use crate::errors::RuntimeError;
 
 #[derive(Clone, Debug)]
 /// HTTP Basic authentication parameters
@@ -86,7 +86,7 @@ pub async fn handle_auth(
     if match_auth(&cred.into(), required_auth) {
         Ok(req)
     } else {
-        Err((ContextualError::InvalidHttpCredentials.into(), req))
+        Err((RuntimeError::InvalidHttpCredentials.into(), req))
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use crate::{renderer::render_error, MiniserveConfig};
 
 #[derive(Debug, Error)]
-pub enum StartError {
+pub enum StartupError {
     /// Any kind of IO errors
     #[error("{0}\ncaused by: {1}")]
     IoError(String, std::io::Error),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,7 +11,23 @@ use thiserror::Error;
 use crate::{renderer::render_error, MiniserveConfig};
 
 #[derive(Debug, Error)]
-pub enum ContextualError {
+pub enum StartError {
+    /// Any kind of IO errors
+    #[error("{0}\ncaused by: {1}")]
+    IoError(String, std::io::Error),
+
+    /// In case miniserve was invoked without an interactive terminal and without an explicit path
+    #[error("Refusing to start as no explicit serve path was set and no interactive terminal was attached
+Please set an explicit serve path like: `miniserve /my/path`")]
+    NoExplicitPathAndNoTerminal,
+
+    /// In case miniserve was invoked with --no-symlinks but the serve path is a symlink
+    #[error("The -P|--no-symlinks option was provided but the serve path '{0}' is a symlink")]
+    NoSymlinksOptionWithSymlinkServePath(String),
+}
+
+#[derive(Debug, Error)]
+pub enum RuntimeError {
     /// Any kind of IO errors
     #[error("{0}\ncaused by: {1}")]
     IoError(String, std::io::Error),
@@ -32,22 +48,6 @@ pub enum ContextualError {
     #[error("Invalid path\ncaused by: {0}")]
     InvalidPathError(String),
 
-    /// Might occur if the HTTP credential string does not respect the expected format
-    #[error("Invalid format for credentials string. Expected username:password, username:sha256:hash or username:sha512:hash")]
-    InvalidAuthFormat,
-
-    /// Might occur if the hash method is neither sha256 nor sha512
-    #[error("{0} is not a valid hashing method. Expected sha256 or sha512")]
-    InvalidHashMethod(String),
-
-    /// Might occur if the HTTP auth hash password is not a valid hex code
-    #[error("Invalid format for password hash. Expected hex code")]
-    InvalidPasswordHash,
-
-    /// Might occur if the HTTP auth password exceeds 255 characters
-    #[error("HTTP password length exceeds 255 characters")]
-    PasswordTooLongError,
-
     /// Might occur if the user has insufficient permissions to create an entry in a given directory
     #[error("Insufficient permissions to create file in {0}")]
     InsufficientPermissionsError(String),
@@ -58,7 +58,7 @@ pub enum ContextualError {
 
     /// Might occur when the creation of an archive fails
     #[error("An error occurred while creating the {0}\ncaused by: {1}")]
-    ArchiveCreationError(String, Box<ContextualError>),
+    ArchiveCreationError(String, Box<RuntimeError>),
 
     /// More specific archive creation failure reason
     #[error("{0}")]
@@ -75,28 +75,25 @@ pub enum ContextualError {
     /// Might occur when trying to access a page that does not exist
     #[error("Route {0} could not be found")]
     RouteNotFoundError(String),
-
-    /// In case miniserve was invoked without an interactive terminal and without an explicit path
-    #[error("Refusing to start as no explicit serve path was set and no interactive terminal was attached
-Please set an explicit serve path like: `miniserve /my/path`")]
-    NoExplicitPathAndNoTerminal,
-
-    /// In case miniserve was invoked with --no-symlinks but the serve path is a symlink
-    #[error("The -P|--no-symlinks option was provided but the serve path '{0}' is a symlink")]
-    NoSymlinksOptionWithSymlinkServePath(String),
 }
 
-impl ResponseError for ContextualError {
+impl ResponseError for RuntimeError {
     fn status_code(&self) -> StatusCode {
+        use RuntimeError as E;
+        use StatusCode as S;
         match self {
-            Self::ArchiveCreationError(_, err) => err.status_code(),
-            Self::RouteNotFoundError(_) => StatusCode::NOT_FOUND,
-            Self::InsufficientPermissionsError(_) => StatusCode::FORBIDDEN,
-            Self::InvalidHttpCredentials => StatusCode::UNAUTHORIZED,
-            Self::InvalidHttpRequestError(_) => StatusCode::BAD_REQUEST,
-            Self::DuplicateFileError => StatusCode::FORBIDDEN,
-            Self::UploadForbiddenError => StatusCode::FORBIDDEN,
-            _ => StatusCode::INTERNAL_SERVER_ERROR,
+            E::IoError(_, _) => S::INTERNAL_SERVER_ERROR,
+            E::MultipartError(_) => S::BAD_REQUEST,
+            E::DuplicateFileError => S::CONFLICT,
+            E::UploadForbiddenError => S::FORBIDDEN,
+            E::InvalidPathError(_) => S::BAD_REQUEST,
+            E::InsufficientPermissionsError(_) => S::FORBIDDEN,
+            E::ParseError(_, _) => S::BAD_REQUEST,
+            E::ArchiveCreationError(_, err) => err.status_code(),
+            E::ArchiveCreationDetailError(_) => S::INTERNAL_SERVER_ERROR,
+            E::InvalidHttpCredentials => S::UNAUTHORIZED,
+            E::InvalidHttpRequestError(_) => S::BAD_REQUEST,
+            E::RouteNotFoundError(_) => S::NOT_FOUND,
         }
     }
 

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -14,7 +14,7 @@ use strum::{Display, EnumString};
 
 use crate::archive::ArchiveMethod;
 use crate::auth::CurrentUser;
-use crate::errors::{self, ContextualError};
+use crate::errors::{self, RuntimeError};
 use crate::renderer;
 
 use self::percent_encode_sets::PATH_SEGMENT;
@@ -400,7 +400,7 @@ pub fn extract_query_parameters(req: &HttpRequest) -> ListingQueryParameters {
     match Query::<ListingQueryParameters>::from_query(req.query_string()) {
         Ok(Query(query_params)) => query_params,
         Err(e) => {
-            let err = ContextualError::ParseError("query parameters".to_string(), e.to_string());
+            let err = RuntimeError::ParseError("query parameters".to_string(), e.to_string());
             errors::log_error_chain(err.to_string());
             ListingQueryParameters::default()
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ mod pipe;
 mod renderer;
 
 use crate::config::MiniserveConfig;
-use crate::errors::ContextualError;
+use crate::errors::{RuntimeError, StartError};
 
 static STYLESHEET: &str = grass::include!("data/style.scss");
 
@@ -61,7 +61,7 @@ fn main() -> Result<()> {
 }
 
 #[actix_web::main(miniserve)]
-async fn run(miniserve_config: MiniserveConfig) -> Result<(), ContextualError> {
+async fn run(miniserve_config: MiniserveConfig) -> Result<(), StartError> {
     let log_level = if miniserve_config.verbose {
         simplelog::LevelFilter::Info
     } else {
@@ -84,16 +84,17 @@ async fn run(miniserve_config: MiniserveConfig) -> Result<(), ContextualError> {
     .expect("Couldn't initialize logger");
 
     if miniserve_config.no_symlinks && miniserve_config.path.is_symlink() {
-        return Err(ContextualError::NoSymlinksOptionWithSymlinkServePath(
+        return Err(StartError::NoSymlinksOptionWithSymlinkServePath(
             miniserve_config.path.to_string_lossy().to_string(),
         ));
     }
 
     let inside_config = miniserve_config.clone();
 
-    let canon_path = miniserve_config.path.canonicalize().map_err(|e| {
-        ContextualError::IoError("Failed to resolve path to be served".to_string(), e)
-    })?;
+    let canon_path = miniserve_config
+        .path
+        .canonicalize()
+        .map_err(|e| StartError::IoError("Failed to resolve path to be served".to_string(), e))?;
 
     // warn if --index is specified but not found
     if let Some(ref index) = miniserve_config.index {
@@ -118,7 +119,7 @@ async fn run(miniserve_config: MiniserveConfig) -> Result<(), ContextualError> {
         // running miniserve as a service but forgetting to set the path. This could be pretty
         // dangerous if given with an undesired context path (for instance /root or /).
         if !io::stdout().is_terminal() {
-            return Err(ContextualError::NoExplicitPathAndNoTerminal);
+            return Err(StartError::NoExplicitPathAndNoTerminal);
         }
 
         warn!("miniserve has been invoked without an explicit path so it will serve the current directory after a short delay.");
@@ -128,12 +129,12 @@ async fn run(miniserve_config: MiniserveConfig) -> Result<(), ContextualError> {
         print!("Starting server in ");
         io::stdout()
             .flush()
-            .map_err(|e| ContextualError::IoError("Failed to write data".to_string(), e))?;
+            .map_err(|e| StartError::IoError("Failed to write data".to_string(), e))?;
         for c in "3… 2… 1… \n".chars() {
             print!("{c}");
             io::stdout()
                 .flush()
-                .map_err(|e| ContextualError::IoError("Failed to write data".to_string(), e))?;
+                .map_err(|e| StartError::IoError("Failed to write data".to_string(), e))?;
             thread::sleep(Duration::from_millis(500));
         }
     }
@@ -223,7 +224,7 @@ async fn run(miniserve_config: MiniserveConfig) -> Result<(), ContextualError> {
 
     let srv = socket_addresses.iter().try_fold(srv, |srv, addr| {
         let listener = create_tcp_listener(*addr)
-            .map_err(|e| ContextualError::IoError(format!("Failed to bind server to {addr}"), e))?;
+            .map_err(|e| StartError::IoError(format!("Failed to bind server to {addr}"), e))?;
 
         #[cfg(feature = "tls")]
         let srv = match &miniserve_config.tls_rustls_config {
@@ -234,7 +235,7 @@ async fn run(miniserve_config: MiniserveConfig) -> Result<(), ContextualError> {
         #[cfg(not(feature = "tls"))]
         let srv = srv.listen(listener);
 
-        srv.map_err(|e| ContextualError::IoError(format!("Failed to bind server to {addr}"), e))
+        srv.map_err(|e| StartError::IoError(format!("Failed to bind server to {addr}"), e))
     })?;
 
     let srv = srv.shutdown_timeout(0).run();
@@ -274,8 +275,7 @@ async fn run(miniserve_config: MiniserveConfig) -> Result<(), ContextualError> {
         println!("Quit by pressing CTRL-C");
     }
 
-    srv.await
-        .map_err(|e| ContextualError::IoError("".to_owned(), e))
+    srv.await.map_err(|e| StartError::IoError("".to_owned(), e))
 }
 
 /// Allows us to set low-level socket options
@@ -378,8 +378,8 @@ fn configure_app(app: &mut web::ServiceConfig, conf: &MiniserveConfig) {
     }
 }
 
-async fn error_404(req: HttpRequest) -> Result<HttpResponse, ContextualError> {
-    Err(ContextualError::RouteNotFoundError(req.path().to_string()))
+async fn error_404(req: HttpRequest) -> Result<HttpResponse, RuntimeError> {
+    Err(RuntimeError::RouteNotFoundError(req.path().to_string()))
 }
 
 async fn favicon() -> impl Responder {


### PR DESCRIPTION
## Motivation

I noticed that the `ResponseError` impl for `ContexualError` was not very complete. Many variants simply default to 500-ISE by wildcard match.

So I tried to fix that, but in the process I realised that some error variants are only encountered at program startup and not at runtime. Therefore I think it's much more appropriate to put them in separate enums.

## Change summary

- Split `ContexualError` into `StartError` & `RuntimeError` & `AuthParseError`
- Made sure every `RuntimeError` variant has an accurate status code