### PR TITLE
Update style.scss

### DIFF
--- a/data/style.scss
+++ b/data/style.scss
@@ -282,6 +282,7 @@ td.date-cell {
 }
 
 span.size {
+    white-space: nowrap;
     border-radius: 1rem;
     background: var(--size_background_color);
     padding: 0 0.25rem;


### PR DESCRIPTION
fix wrapping text in mobile view when the file name too long, the box of file size become inconsistent.
![PR](https://github.com/svenstaro/miniserve/assets/18382453/02baad9b-196d-4a5f-afdf-dd71f465797d)
