### PR TITLE
new flag: Enable renaming during file upload if duplicate exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,10 +312,15 @@ Options:
 
           [env: MINISERVE_RAW_MEDIA_TYPE=]
 
-  -o, --overwrite-files
-          Enable overriding existing files during file upload
+  -o, --on-duplicate-files <ON_DUPLICATE_FILES>
+          What to do if existing files with same name is present during file upload
 
-          [env: MINISERVE_OVERWRITE_FILES=]
+          If you enable renaming files, the renaming will occur by adding numerical suffix to the filename before the final extension. For example file.txt will be uploaded
+          as file-1.txt, the number will be increased until an available filename is found.
+
+          [env: MINISERVE_ON_DUPLICATE_FILES=]
+          [default: error]
+          [possible values: error, overwrite, rename]
 
   -r, --enable-tar
           Enable uncompressed tar archive generation
@@ -543,7 +548,7 @@ You can provide `-i` multiple times to bind to multiple interfaces at the same t
 
 This is mostly a note for me on how to release this thing:
 
-- Make sure `CHANGELOG.md` is up to date.
+- Make sure [CHANGELOG.md](./CHANGELOG.md) is up to date.
 - `cargo release <version>`
 - `cargo release --execute <version>`
 - Releases will automatically be deployed by GitHub Actions.

--- a/src/args.rs
+++ b/src/args.rs
@@ -262,7 +262,7 @@ pub struct CliArgs {
     /// What to do if existing files with same name is present during file upload
     ///
     /// If you enable renaming files, the renaming will occur by
-    /// adding numerical suffix to the filename before the final
+    /// adding a numerical suffix to the filename before the final
     /// extension. For example file.txt will be uploaded as
     /// file-1.txt, the number will be increased until an available
     /// filename is found.

--- a/src/args.rs
+++ b/src/args.rs
@@ -16,6 +16,14 @@ pub enum MediaType {
     Video,
 }
 
+#[derive(Debug, ValueEnum, Clone, Default, Copy)]
+pub enum DuplicateFile {
+    #[default]
+    Error,
+    Overwrite,
+    Rename,
+}
+
 #[derive(ValueEnum, Clone)]
 pub enum SizeDisplay {
     Human,
@@ -251,13 +259,20 @@ pub struct CliArgs {
     )]
     pub media_type_raw: Option<String>,
 
-    /// Enable overriding existing files during file upload
+    /// What to do if existing files with same name is present during file upload
+    ///
+    /// If you enable renaming files, the renaming will occur by
+    /// adding numerical suffix to the filename before the final
+    /// extension. For example file.txt will be uploaded as
+    /// file-1.txt, the number will be increased until an available
+    /// filename is found.
     #[arg(
         short = 'o',
-        long = "overwrite-files",
-        env = "MINISERVE_OVERWRITE_FILES"
+        long = "on-duplicate-files",
+        env = "MINISERVE_ON_DUPLICATE_FILES",
+        default_value = "error"
     )]
-    pub overwrite_files: bool,
+    pub on_duplicate_files: DuplicateFile,
 
     /// Enable uncompressed tar archive generation
     #[arg(short = 'r', long = "enable-tar", env = "MINISERVE_ENABLE_TAR")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,7 @@ use anyhow::{Context, Result, anyhow};
 use rustls_pemfile as pemfile;
 
 use crate::{
-    args::{CliArgs, MediaType, parse_auth},
+    args::{CliArgs, DuplicateFile, MediaType, parse_auth},
     auth::RequiredAuth,
     file_utils::sanitize_path,
     listing::{SortingMethod, SortingOrder},
@@ -122,8 +122,8 @@ pub struct MiniserveConfig {
     /// HTML accept attribute value
     pub uploadable_media_type: Option<String>,
 
-    /// Enable upload to override existing files
-    pub overwrite_files: bool,
+    /// What to do on upload if filename already exists
+    pub on_duplicate_files: DuplicateFile,
 
     /// If false, creation of uncompressed tar archives is disabled
     pub tar_enabled: bool,
@@ -321,7 +321,7 @@ impl MiniserveConfig {
             index: args.index,
             spa: args.spa,
             pretty_urls: args.pretty_urls,
-            overwrite_files: args.overwrite_files,
+            on_duplicate_files: args.on_duplicate_files,
             show_qrcode: args.qrcode,
             directory_size: args.directory_size,
             mkdir_enabled: args.mkdir_enabled,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -42,7 +42,7 @@ pub enum RuntimeError {
     MultipartError(String),
 
     /// Might occur during file upload
-    #[error("File already exists, and the overwrite_files option has not been set")]
+    #[error("File already exists, and the on_duplicate_files option is set to error out")]
     DuplicateFileError,
 
     /// Uploaded hash not correct

--- a/src/file_op.rs
+++ b/src/file_op.rs
@@ -131,6 +131,7 @@ async fn save_file(
                     } else {
                         file_path.with_file_name(format!("{}-{}", file_name, i))
                     };
+                    // If we have a file name that doesn't exist yet then we'll use that.
                     if !fp.exists() {
                         file_path = fp;
                         break;

--- a/src/file_op.rs
+++ b/src/file_op.rs
@@ -27,8 +27,8 @@ use tokio::io::AsyncWriteExt;
 use tokio::sync::RwLock;
 
 use crate::{
-    config::MiniserveConfig, errors::RuntimeError, file_utils::contains_symlink,
-    file_utils::sanitize_path,
+    args::DuplicateFile, config::MiniserveConfig, errors::RuntimeError,
+    file_utils::contains_symlink, file_utils::sanitize_path,
 };
 
 enum FileHash {
@@ -109,13 +109,35 @@ pub async fn recursive_dir_size(dir: &Path) -> Result<u64, RuntimeError> {
 /// Returns total bytes written to file.
 async fn save_file(
     field: &mut actix_multipart::Field,
-    file_path: PathBuf,
-    overwrite_files: bool,
+    mut file_path: PathBuf,
+    on_duplicate_files: DuplicateFile,
     file_checksum: Option<&FileHash>,
     temporary_upload_directory: Option<&PathBuf>,
 ) -> Result<u64, RuntimeError> {
-    if !overwrite_files && file_path.exists() {
-        return Err(RuntimeError::DuplicateFileError);
+    if file_path.exists() {
+        match on_duplicate_files {
+            DuplicateFile::Error => return Err(RuntimeError::DuplicateFileError),
+            DuplicateFile::Overwrite => (),
+            DuplicateFile::Rename => {
+                // extract extension of the file and the file stem without extension
+                // file.txt => (file, txt)
+                let file_name = file_path.file_stem().unwrap_or_default().to_string_lossy();
+                let file_ext = file_path.extension().map(|s| s.to_string_lossy());
+                for i in 1.. {
+                    // increment the number N in {file_name}-{N}.{file_ext}
+                    // format until available name is found (e.g. file-1.txt, file-2.txt, etc)
+                    let fp = if let Some(ext) = &file_ext {
+                        file_path.with_file_name(format!("{}-{}.{}", file_name, i, ext))
+                    } else {
+                        file_path.with_file_name(format!("{}-{}", file_name, i))
+                    };
+                    if !fp.exists() {
+                        file_path = fp;
+                        break;
+                    }
+                }
+            }
+        }
     }
 
     let temp_upload_directory = temporary_upload_directory.cloned();
@@ -258,7 +280,7 @@ async fn save_file(
 }
 
 struct HandleMultipartOpts<'a> {
-    overwrite_files: bool,
+    on_duplicate_files: DuplicateFile,
     allow_mkdir: bool,
     allow_hidden_paths: bool,
     allow_symlinks: bool,
@@ -273,7 +295,7 @@ async fn handle_multipart(
     opts: HandleMultipartOpts<'_>,
 ) -> Result<u64, RuntimeError> {
     let HandleMultipartOpts {
-        overwrite_files,
+        on_duplicate_files,
         allow_mkdir,
         allow_hidden_paths,
         allow_symlinks,
@@ -390,7 +412,7 @@ async fn handle_multipart(
     save_file(
         &mut field,
         path.join(filename_path),
-        overwrite_files,
+        on_duplicate_files,
         file_hash,
         upload_directory,
     )
@@ -475,7 +497,7 @@ pub async fn upload_file(
                 field,
                 non_canonicalized_target_dir.clone(),
                 HandleMultipartOpts {
-                    overwrite_files: conf.overwrite_files,
+                    on_duplicate_files: conf.on_duplicate_files,
                     allow_mkdir: conf.mkdir_enabled,
                     allow_hidden_paths: conf.show_hidden,
                     allow_symlinks: !conf.no_symlinks,

--- a/tests/upload_files.rs
+++ b/tests/upload_files.rs
@@ -268,6 +268,161 @@ fn uploading_files_to_allowed_dir_works(
     Ok(())
 }
 
+#[rstest]
+#[case(server(&["-u"]))]
+#[case(server(&["-u", "-o", "error"]))]
+#[case(server(&["-u", "--on-duplicate-files", "error"]))]
+fn uploading_duplicate_file_is_prevented(#[case] server: TestServer) -> Result<(), Error> {
+    let test_file_name = "duplicate test file.txt";
+    let test_file_contents = "Test File Contents";
+    let test_file_contents_new = "New Uploaded Test File Contents";
+
+    // create the file
+    let test_file_path = server.path().join(test_file_name);
+    let _ = std::fs::write(&test_file_path, test_file_contents);
+
+    // Before uploading, make sure the file is there.
+    let body = reqwest::blocking::get(server.url())?.error_for_status()?;
+    let parsed = Document::from_read(body)?;
+    assert!(parsed.find(Text).any(|x| x.text() == test_file_name));
+
+    // Perform the actual upload.
+    let upload_action = parsed
+        .find(Attr("id", "file_submit"))
+        .next()
+        .expect("Couldn't find element with id=file_submit")
+        .attr("action")
+        .expect("Upload form doesn't have action attribute");
+    // Then try to upload anyway
+    let form = multipart::Form::new();
+    let part = multipart::Part::text(test_file_contents_new)
+        .file_name(test_file_name)
+        .mime_str("text/plain")?;
+    let form = form.part("file_to_upload", part);
+
+    let client = Client::new();
+    // Ensure uploading fails and returns an error
+    assert!(
+        client
+            .post(server.url().join(upload_action)?)
+            .multipart(form)
+            .send()?
+            .error_for_status()
+            .is_err()
+    );
+
+    // After uploading, uploaded file is still getting listed.
+    let body = reqwest::blocking::get(server.url())?;
+    let parsed = Document::from_read(body)?;
+    assert!(parsed.find(Text).any(|x| x.text() == test_file_name));
+    // and assert the contents is the same as before
+    assert_file_contents(&test_file_path, test_file_contents);
+
+    Ok(())
+}
+
+#[rstest]
+#[case(server(&["-u", "-o", "overwrite"]))]
+#[case(server(&["-u", "--on-duplicate-files", "overwrite"]))]
+fn overwrite_duplicate_file(#[case] server: TestServer) -> Result<(), Error> {
+    let test_file_name = "duplicate test file.txt";
+    let test_file_contents = "Test File Contents";
+    let test_file_contents_new = "New Uploaded Test File Contents";
+
+    // create the file
+    let test_file_path = server.path().join(test_file_name);
+    let _ = std::fs::write(&test_file_path, test_file_contents);
+
+    // Before uploading, make sure the file is there.
+    let body = reqwest::blocking::get(server.url())?.error_for_status()?;
+    let parsed = Document::from_read(body)?;
+    assert!(parsed.find(Text).any(|x| x.text() == test_file_name));
+
+    // Perform the actual upload.
+    let upload_action = parsed
+        .find(Attr("id", "file_submit"))
+        .next()
+        .expect("Couldn't find element with id=file_submit")
+        .attr("action")
+        .expect("Upload form doesn't have action attribute");
+    // Then try to upload anyway
+    let form = multipart::Form::new();
+    let part = multipart::Part::text(test_file_contents_new)
+        .file_name(test_file_name)
+        .mime_str("text/plain")?;
+    let form = form.part("file_to_upload", part);
+
+    let client = Client::new();
+    client
+        .post(server.url().join(upload_action)?)
+        .multipart(form)
+        .send()?
+        .error_for_status()?;
+
+    // After uploading, uploaded file is still getting listed.
+    let body = reqwest::blocking::get(server.url())?;
+    let parsed = Document::from_read(body)?;
+    assert!(parsed.find(Text).any(|x| x.text() == test_file_name));
+    // and assert the contents is the same as before
+    assert_file_contents(&test_file_path, test_file_contents_new);
+
+    Ok(())
+}
+
+#[rstest]
+#[case(server(&["-u", "-o", "rename"]))]
+#[case(server(&["-u", "--on-duplicate-files", "rename"]))]
+fn rename_duplicate_file(#[case] server: TestServer) -> Result<(), Error> {
+    let test_file_name = "duplicate test file.txt";
+    let test_file_contents = "Test File Contents";
+    let test_file_name_new = "duplicate test file-1.txt";
+    let test_file_contents_new = "New Uploaded Test File Contents";
+
+    // create the file
+    let test_file_path = server.path().join(test_file_name);
+    let _ = std::fs::write(&test_file_path, test_file_contents);
+
+    // Before uploading, make sure the file is there.
+    let body = reqwest::blocking::get(server.url())?.error_for_status()?;
+    let parsed = Document::from_read(body)?;
+    assert!(parsed.find(Text).any(|x| x.text() == test_file_name));
+
+    // Perform the actual upload.
+    let upload_action = parsed
+        .find(Attr("id", "file_submit"))
+        .next()
+        .expect("Couldn't find element with id=file_submit")
+        .attr("action")
+        .expect("Upload form doesn't have action attribute");
+    // Then try to upload anyway
+    let form = multipart::Form::new();
+    let part = multipart::Part::text(test_file_contents_new)
+        .file_name(test_file_name)
+        .mime_str("text/plain")?;
+    let form = form.part("file_to_upload", part);
+
+    let client = Client::new();
+    client
+        .post(server.url().join(upload_action)?)
+        .multipart(form)
+        .send()?
+        .error_for_status()?;
+
+    // After uploading, uploaded file is still getting listed.
+    let body = reqwest::blocking::get(server.url())?;
+    let parsed = Document::from_read(body)?;
+    assert!(parsed.find(Text).any(|x| x.text() == test_file_name));
+    assert!(parsed.find(Text).any(|x| x.text() == test_file_name_new));
+    // and assert the contents is the same as before
+    assert_file_contents(&test_file_path, test_file_contents);
+    assert_file_contents(
+        &server.path().join(test_file_name_new),
+        test_file_contents_new,
+    );
+
+    Ok(())
+}
+
 /// Test for path traversal vulnerability (CWE-22) in both path parameter of query string and in
 /// file name (Content-Disposition)
 ///
@@ -374,4 +529,9 @@ fn set_media_type(
     assert_eq!(input.attr("accept"), expected_accept_value);
 
     Ok(())
+}
+
+fn assert_file_contents(file_path: &Path, contents: &str) {
+    let file_contents = std::fs::read_to_string(file_path).unwrap();
+    assert!(file_contents == contents)
 }

--- a/tests/upload_files.rs
+++ b/tests/upload_files.rs
@@ -279,7 +279,7 @@ fn uploading_duplicate_file_is_prevented(#[case] server: TestServer) -> Result<(
 
     // create the file
     let test_file_path = server.path().join(test_file_name);
-    let _ = std::fs::write(&test_file_path, test_file_contents);
+    std::fs::write(&test_file_path, test_file_contents)?;
 
     // Before uploading, make sure the file is there.
     let body = reqwest::blocking::get(server.url())?.error_for_status()?;
@@ -359,11 +359,11 @@ fn overwrite_duplicate_file(#[case] server: TestServer) -> Result<(), Error> {
         .send()?
         .error_for_status()?;
 
-    // After uploading, uploaded file is still getting listed.
+    // After uploading, verify the listing has the file
     let body = reqwest::blocking::get(server.url())?;
     let parsed = Document::from_read(body)?;
     assert!(parsed.find(Text).any(|x| x.text() == test_file_name));
-    // and assert the contents is the same as before
+    // and assert the contents is from recently uploaded file
     assert_file_contents(&test_file_path, test_file_contents_new);
 
     Ok(())
@@ -408,12 +408,12 @@ fn rename_duplicate_file(#[case] server: TestServer) -> Result<(), Error> {
         .send()?
         .error_for_status()?;
 
-    // After uploading, uploaded file is still getting listed.
+    // After uploading, assert the old file is still getting listed, and the new file is also in listing
     let body = reqwest::blocking::get(server.url())?;
     let parsed = Document::from_read(body)?;
     assert!(parsed.find(Text).any(|x| x.text() == test_file_name));
     assert!(parsed.find(Text).any(|x| x.text() == test_file_name_new));
-    // and assert the contents is the same as before
+    // and assert the contents is the same as before for old file, and new contents for new file
     assert_file_contents(&test_file_path, test_file_contents);
     assert_file_contents(
         &server.path().join(test_file_name_new),


### PR DESCRIPTION
Fixes #1452

I think this will work as a flag to rename files. It won't work when the file contains multiple extension like `.tar.gz` which is hard to do, as we could make it work with that, but any file with multiple `.` in the text for no meaning will mess it up. But I can make that change if you think that's acceptable.

Also, it will break compatibility, but we could combine the overwrite and rename flags into a single flag like `--duplicate-files` that takes enum (rename/overwrite).
