### PR TITLE
move favicon and css to stable, non-random routes

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -196,13 +196,13 @@ impl MiniserveConfig {
         // Otherwise, we should apply route_prefix to static files.
         let (favicon_route, css_route) = if args.random_route {
             (
-                format!("/{}", nanoid::nanoid!(10, &ROUTE_ALPHABET)),
-                format!("/{}", nanoid::nanoid!(10, &ROUTE_ALPHABET)),
+                "/__miniserve_internal/favicon.svg".into(),
+                "/__miniserve_internal/style.css".into(),
             )
         } else {
             (
-                format!("{}/{}", route_prefix, nanoid::nanoid!(10, &ROUTE_ALPHABET)),
-                format!("{}/{}", route_prefix, nanoid::nanoid!(10, &ROUTE_ALPHABET)),
+                format!("{}/{}", route_prefix, "__miniserve_internal/favicon.ico"),
+                format!("{}/{}", route_prefix, "__miniserve_internal/style.css"),
             )
         };
 

--- a/tests/serve_request.rs
+++ b/tests/serve_request.rs
@@ -290,9 +290,9 @@ fn serves_requests_with_route_prefix(#[case] server: TestServer) -> Result<(), E
 }
 
 #[rstest]
-#[case(server(&[] as &[&str]), "/[a-f0-9]+")]
-#[case(server(&["--random-route"]), "/[a-f0-9]+")]
-#[case(server(&["--route-prefix", "foobar"]), "/foobar/[a-f0-9]+")]
+#[case(server(&[] as &[&str]), "/__miniserve_internal/[a-z.]+")]
+#[case(server(&["--random-route"]), "/__miniserve_internal/[a-z.]+")]
+#[case(server(&["--route-prefix", "foobar"]), "/foobar/__miniserve_internal/[a-z.]+")]
 fn serves_requests_static_file_check(
     #[case] server: TestServer,
     #[case] static_file_pattern: String,


### PR DESCRIPTION
Favicon and stylesheet are currently served at random paths in order to avoid collisions. However, this causes problems with [running multi-replica deployments](https://github.com/svenstaro/miniserve/issues/1424) as well as caching, because the path is not stable across multiple instances/restarts of miniserve.

In order to address this, this PR moves the paths to stable routes prefixed by "__miniserve_internal", which should provide enough protection from accidental collisions.