### PR TITLE
Add date pill and sort links for mobile views

### DIFF
--- a/data/style.scss
+++ b/data/style.scss
@@ -281,17 +281,22 @@ td.date-cell {
     color: var(--date_text_color);
 }
 
-span.size {
+span.size, span.mobile-info.history {
     white-space: nowrap;
     border-radius: 1rem;
     background: var(--size_background_color);
     padding: 0 0.25rem;
+    margin: 0 0.25rem;
     font-size: 0.7rem;
     color: var(--size_text_color);
 }
 
 .mobile-info {
     display: none;
+}
+
+.mobile-info a, .mobile-info a:visited {
+    color: var(--size_text_color);
 }
 
 th a,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -521,7 +521,12 @@ fn entry_row(
                         @if !raw {
                             @if let Some(size) = entry.size {
                                 span.mobile-info.size {
-                                    (maud::display(size))
+                                    (build_link("size", &format!("{}", size), sort_method, sort_order))
+                                }
+                            }
+                            @if let Some(modification_timer) = humanize_systemtime(entry.last_modification_date) {
+                                span.mobile-info.history {
+                                    (build_link("date", &modification_timer, sort_method, sort_order))
                                 }
                             }
                         }


### PR DESCRIPTION
Adds a mobile view pill for the relative date, and creates clickable links to sort via those pills.

It was annoying to have to turn my phone sideways to be able to sort by the hidden date and size columns, and I think this is a decent solution while keeping the overall mobile feel.