### PR TITLE
Add asynchronous directory size counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add upload progress bar and allow for multiple concurrent file uploads [#1431](https://github.com/svenstaro/miniserve/pull/1431) (thanks @AlecDivito)
 - Add `--size-display` to allow for toggling file size display between `human` and `exact` [#1261](https://github.com/svenstaro/miniserve/pull/1261) (thanks @Lzzzzzt)
 - Add well-known healthcheck route at `/__miniserve_internal/healthcheck` (of `/<prefix>/__miniserve_internal/healthcheck` when using `--route-prefix`)
+- Add asynchronous recursive directory size counting [#1482](https://github.com/svenstaro/miniserve/pull/1482)
 
 ## [0.29.0] - 2025-02-06
 - Make URL encoding fully WHATWG-compliant [#1454](https://github.com/svenstaro/miniserve/pull/1454) (thanks @cyqsimon)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +512,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "async-walkdir"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37672978ae0febce7516ae0a85b53e6185159a9a28787391eb63fc44ec36037d"
+dependencies = [
+ "async-fs",
+ "futures-lite",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -541,6 +592,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -757,6 +821,15 @@ dependencies = [
  "slug",
  "typed-arena",
  "unicode_categories",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1051,6 +1124,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fake-tty"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,6 +1286,19 @@ name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -2059,6 +2166,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "assert_fs",
+ "async-walkdir",
  "bytesize",
  "chrono",
  "chrono-humanize",
@@ -2247,6 +2355,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2398,6 +2512,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkg-config"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ actix-web = { version = "4", features = ["macros", "compress-brotli", "compress-
 actix-web-httpauth = "0.8"
 alphanumeric-sort = "1"
 anyhow = "1"
+async-walkdir = "2.1.0"
 bytesize = "2"
 chrono = "0.4"
 chrono-humanize = "0.2"
@@ -74,7 +75,7 @@ assert_fs = "1"
 predicates = "3"
 pretty_assertions = "1.2"
 regex = "1"
-reqwest = { version = "0.12", features = ["blocking", "multipart", "rustls-tls"], default-features = false }
+reqwest = { version = "0.12", features = ["blocking", "multipart", "json", "rustls-tls"], default-features = false }
 reqwest_dav = "0.1"
 rstest = "0.24"
 select = "0.6"

--- a/data/style.scss
+++ b/data/style.scss
@@ -428,6 +428,25 @@ td.date-cell {
   justify-content: space-between;
 }
 
+.loading-indicator {
+  width: 65%;
+  height: 15px;
+  margin-left: 35%;
+  animation: shimmer 2s infinite;
+  background: linear-gradient(to right, #e6e6e655 5%, #77777755 25%, #e6e6e655 35%);
+  background-size: 500px 100%;
+}
+
+@keyframes shimmer {
+  from {
+    background-position: -500px 0;
+  }
+
+  to {
+    background-position: 500px 0;
+  }
+}
+
 .history {
   color: var(--date_text_color);
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -367,7 +367,7 @@ pub struct CliArgs {
     #[arg(long, env = "MINISERVE_ENABLE_WEBDAV", conflicts_with = "no_symlinks")]
     pub enable_webdav: bool,
 
-    /// Show served file size in exact bytes.
+    /// Show served file size in exact bytes
     #[arg(long, default_value_t = SizeDisplay::Human, env = "MINISERVE_SIZE_DISPLAY")]
     pub size_display: SizeDisplay,
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,4 +1,4 @@
-use actix_web::{HttpMessage, dev::ServiceRequest};
+use actix_web::{HttpMessage, dev::ServiceRequest, web};
 use actix_web_httpauth::extractors::basic::BasicAuth;
 use sha2::{Digest, Sha256, Sha512};
 
@@ -77,7 +77,10 @@ pub async fn handle_auth(
     req: ServiceRequest,
     cred: BasicAuth,
 ) -> actix_web::Result<ServiceRequest, (actix_web::Error, ServiceRequest)> {
-    let required_auth = &req.app_data::<crate::MiniserveConfig>().unwrap().auth;
+    let required_auth = &req
+        .app_data::<web::Data<crate::MiniserveConfig>>()
+        .unwrap()
+        .auth;
 
     req.extensions_mut().insert(CurrentUser {
         name: cred.user_id().to_string(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,7 @@ const ROUTE_ALPHABET: [char; 16] = [
     '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', 'a', 'b', 'c', 'd', 'e', 'f',
 ];
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 /// Configuration of the Miniserve application
 pub struct MiniserveConfig {
     /// Enable verbose mode
@@ -65,6 +65,9 @@ pub struct MiniserveConfig {
 
     /// Well-known healthcheck route (prefixed if route_prefix is provided)
     pub healthcheck_route: String,
+
+    /// Well-known API route (prefixed if route_prefix is provided)
+    pub api_route: String,
 
     /// Well-known favicon route (prefixed if route_prefix is provided)
     pub favicon_route: String,
@@ -206,15 +209,17 @@ impl MiniserveConfig {
         // If --random-route is enabled, in order to not leak the random generated route, we must not use it
         // as static files prefix.
         // Otherwise, we should apply route_prefix to static files.
-        let (healthcheck_route, favicon_route, css_route) = if args.random_route {
+        let (healthcheck_route, api_route, favicon_route, css_route) = if args.random_route {
             (
                 "/__miniserve_internal/healthcheck".into(),
+                "/__miniserve_internal/api".into(),
                 "/__miniserve_internal/favicon.svg".into(),
                 "/__miniserve_internal/style.css".into(),
             )
         } else {
             (
                 format!("{}/{}", route_prefix, "__miniserve_internal/healthcheck"),
+                format!("{}/{}", route_prefix, "__miniserve_internal/api"),
                 format!("{}/{}", route_prefix, "__miniserve_internal/favicon.svg"),
                 format!("{}/{}", route_prefix, "__miniserve_internal/style.css"),
             )
@@ -305,6 +310,7 @@ impl MiniserveConfig {
             default_sorting_order: args.default_sorting_order,
             route_prefix,
             healthcheck_route,
+            api_route,
             favicon_route,
             css_route,
             default_color_scheme,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,6 +6,7 @@ use actix_web::{
     dev::{ResponseHead, ServiceRequest, ServiceResponse},
     http::{StatusCode, header},
     middleware::Next,
+    web,
 };
 use thiserror::Error;
 
@@ -159,7 +160,7 @@ fn map_error_page(req: &HttpRequest, head: &mut ResponseHead, body: BoxBody) -> 
         _ => return BoxBody::new(error_msg),
     };
 
-    let conf = req.app_data::<MiniserveConfig>().unwrap();
+    let conf = req.app_data::<web::Data<MiniserveConfig>>().unwrap();
     let return_address = req
         .headers()
         .get(header::REFERER)

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -1,0 +1,53 @@
+use std::collections::HashMap;
+
+use reqwest::{StatusCode, blocking::Client};
+use rstest::rstest;
+
+mod fixtures;
+
+use crate::fixtures::{DIRECTORIES, Error, TestServer, server};
+
+#[rstest]
+fn api_dir_size(server: TestServer) -> Result<(), Error> {
+    let mut command = HashMap::new();
+    command.insert("DirSize", DIRECTORIES[0]);
+
+    let resp = Client::new()
+        .post(server.url().join(&format!("__miniserve_internal/api"))?)
+        .json(&command)
+        .send()?
+        .error_for_status()?;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_ne!(resp.text()?, "0 B");
+
+    Ok(())
+}
+
+/// Test for path traversal vulnerability (CWE-22) in DirSize parameter.
+#[rstest]
+#[case("/tmp")] // Not CWE-22, but `foo` isn't a directory
+#[case("/../foo")]
+#[case("../foo")]
+#[case("../tmp")]
+#[case("/tmp")]
+#[case("/foo")]
+#[case("C:/foo")]
+#[case(r"C:\foo")]
+#[case(r"\foo")]
+fn api_dir_size_prevent_path_transversal_attacks(
+    server: TestServer,
+    #[case] path: &str,
+) -> Result<(), Error> {
+    let mut command = HashMap::new();
+    command.insert("DirSize", path);
+
+    let resp = Client::new()
+        .post(server.url().join(&format!("__miniserve_internal/api"))?)
+        .json(&command)
+        .send()?;
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+    Ok(())
+}

--- a/tests/serve_request.rs
+++ b/tests/serve_request.rs
@@ -86,6 +86,9 @@ fn serves_requests_with_non_default_port(server: TestServer) -> Result<(), Error
 #[case("__miniserve_internal/healthcheck", server(&["--random-route"]))]
 #[case("__miniserve_internal/favicon.svg", server(&["--random-route"]))]
 #[case("__miniserve_internal/style.css", server(&["--random-route"]))]
+#[case("__miniserve_internal/healthcheck", server(&["--auth", "doesnt:matter"]))]
+#[case("__miniserve_internal/favicon.svg", server(&["--auth", "doesnt:matter"]))]
+#[case("__miniserve_internal/style.css", server(&["--auth", "doesnt:matter"]))]
 fn serves_requests_for_special_routes(
     #[case] route: &str,
     #[case] server: TestServer,


### PR DESCRIPTION
This is enabled by default and without an option to toggle it off as it's asynchronous and shouldn't block the server thread.

Fixes #306 and supersedes #965.