### PR TITLE
Fix: size display for dirs with spaces in the name

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -682,9 +682,9 @@ fn page_header(
                             },
                             method: 'POST',
                             body: JSON.stringify({
-                                DirSize: dir
+                                DirSize: decodeURI(dir)
                             })
-                        }).then(resp => resp.text())
+                        }).then(resp => resp.ok ? resp.text() : "~")
                     }
 
                     // Initialize shimmer effects for .size-cell elements in .entry-type-directory rows


### PR DESCRIPTION
DirSize requests for dirs with a space in the name contain a urlencoded name (eg. { DirSize: "/hello%20world" }), leading to a 400 Bad Request. The frontend then injects the error response body directly into the page.

1. Handle failures by returning a default string if this request fails.
2. Decode the payload before the request is issued.

**Before:**

<img width="1805" alt="image" src="https://github.com/user-attachments/assets/f7617fb1-37b4-454b-b032-3696852f16b2" />

**After, upon request failure:**

<img width="1844" alt="image" src="https://github.com/user-attachments/assets/16907cf7-0e21-48c5-b6b7-104d2b3def29" />

**After, with uridecoded payloads:**

<img width="1836" alt="image" src="https://github.com/user-attachments/assets/82ae7104-c230-40fe-978e-47851327f992" />

## Notes

- Decoding this on the server along with a test is probably a better way of doing this.

