### PR TITLE
Adding an option to serve files from a different server

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ Options:
           one authenticated instance for browsing, linking files (via this option) to a second,
           non-indexed (-I) instance for direct downloads. This obscures the full file list on
           the download server, while users can still copy direct file URLs for sharing.
+          The external URL is put verbatim in front of the relative location of the file, including the protocol.
+          The user should take care this results in a valid URL, no further checks are being done.
       
           [env: MINISERVE_FILE_EXTERNAL_URL=]
 

--- a/README.md
+++ b/README.md
@@ -231,10 +231,14 @@ Options:
 
           [env: MINISERVE_RANDOM_ROUTE=]
 
-      --file-base-url <FILE_BASE_URL>
-          Optional base URL (e.g., 'http://external.example.com:8081') to prepend to file links
-
-          [env: MINISERVE_FILE_BASE_URL=]
+      --file-external-url <FILE_BASE_URL>
+          Optional external URL (e.g., 'http://external.example.com:8081') prepended to file links in listings.
+          Allows serving files from a different URL than the browsing instance. Useful for setups like:
+          one authenticated instance for browsing, linking files (via this option) to a second,
+          non-indexed (-I) instance for direct downloads. This obscures the full file list on
+          the download server, while users can still copy direct file URLs for sharing.
+      
+          [env: MINISERVE_FILE_EXTERNAL_URL=]
 
   -P, --no-symlinks
           Hide symlinks in listing and prevent them from being followed

--- a/README.md
+++ b/README.md
@@ -231,6 +231,11 @@ Options:
 
           [env: MINISERVE_RANDOM_ROUTE=]
 
+      --file-base-url <FILE_BASE_URL>
+          Optional base URL (e.g., 'http://external.example.com:8081') to prepend to file links
+
+          [env: MINISERVE_FILE_BASE_URL=]
+
   -P, --no-symlinks
           Hide symlinks in listing and prevent them from being followed
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -377,9 +377,13 @@ pub struct CliArgs {
     #[arg(long, default_value_t = SizeDisplay::Human, env = "MINISERVE_SIZE_DISPLAY")]
     pub size_display: SizeDisplay,
 
-    /// Optional base URL (e.g., 'http://external.example.com:8081') to prepend to file links
-    #[arg(long = "file-base-url", env = "MINISERVE_FILE_BASE_URL")]
-    pub file_base_url: Option<String>,
+    /// Optional external URL (e.g., 'http://external.example.com:8081') prepended to file links in listings.
+    /// Allows serving files from a different URL than the browsing instance. Useful for setups like:
+    /// one authenticated instance for browsing, linking files (via this option) to a second,
+    /// non-indexed (-I) instance for direct downloads. This obscures the full file list on
+    /// the download server, while users can still copy direct file URLs for sharing.
+    #[arg(long = "file-external-url", env = "MINISERVE_FILE_EXTERNAL_URL")]
+    pub file_external_url: Option<String>,
 }
 
 /// Checks whether an interface is valid, i.e. it can be parsed into an IP address

--- a/src/args.rs
+++ b/src/args.rs
@@ -383,6 +383,8 @@ pub struct CliArgs {
     /// one authenticated instance for browsing, linking files (via this option) to a second,
     /// non-indexed (-I) instance for direct downloads. This obscures the full file list on
     /// the download server, while users can still copy direct file URLs for sharing.
+    /// The external URL is put verbatim in front of the relative location of the file, including the protocol.
+    /// The user should take care this results in a valid URL, no further checks are being done.
     #[arg(long = "file-external-url", env = "MINISERVE_FILE_EXTERNAL_URL")]
     pub file_external_url: Option<String>,
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -376,6 +376,10 @@ pub struct CliArgs {
     /// Show served file size in exact bytes
     #[arg(long, default_value_t = SizeDisplay::Human, env = "MINISERVE_SIZE_DISPLAY")]
     pub size_display: SizeDisplay,
+
+    /// Optional base URL (e.g., 'http://external.example.com:8081') to prepend to file links
+    #[arg(long = "file-base-url", env = "MINISERVE_FILE_BASE_URL")]
+    pub file_base_url: Option<String>,
 }
 
 /// Checks whether an interface is valid, i.e. it can be parsed into an IP address

--- a/src/args.rs
+++ b/src/args.rs
@@ -378,6 +378,7 @@ pub struct CliArgs {
     pub size_display: SizeDisplay,
 
     /// Optional external URL (e.g., 'http://external.example.com:8081') prepended to file links in listings.
+    ///
     /// Allows serving files from a different URL than the browsing instance. Useful for setups like:
     /// one authenticated instance for browsing, linking files (via this option) to a second,
     /// non-indexed (-I) instance for direct downloads. This obscures the full file list on

--- a/src/config.rs
+++ b/src/config.rs
@@ -177,8 +177,8 @@ pub struct MiniserveConfig {
     #[cfg(not(feature = "tls"))]
     pub tls_rustls_config: Option<()>,
 
-    /// Optional base URL to prepend to file links in listings
-    pub file_base_url: Option<String>,
+    /// Optional external URL to prepend to file links in listings
+    pub file_external_url: Option<String>,
 }
 
 impl MiniserveConfig {
@@ -348,7 +348,7 @@ impl MiniserveConfig {
             tls_rustls_config: tls_rustls_server_config,
             compress_response: args.compress_response,
             show_exact_bytes,
-            file_base_url: args.file_base_url,
+            file_external_url: args.file_external_url,
         })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -176,6 +176,9 @@ pub struct MiniserveConfig {
 
     #[cfg(not(feature = "tls"))]
     pub tls_rustls_config: Option<()>,
+
+    /// Optional base URL to prepend to file links in listings
+    pub file_base_url: Option<String>,
 }
 
 impl MiniserveConfig {
@@ -345,6 +348,7 @@ impl MiniserveConfig {
             tls_rustls_config: tls_rustls_server_config,
             compress_response: args.compress_response,
             show_exact_bytes,
+            file_base_url: args.file_base_url,
         })
     }
 }

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -290,10 +290,43 @@ pub fn directory_listing(
                         symlink_dest,
                     ));
                 } else if metadata.is_file() {
-                    entries.push(Entry::new(
+                let file_link = match &conf.file_base_url {
+                    Some(base_url) => {
+                        // Construct the full relative path including subdirectories
+                        // encoded_dir holds the current directory path relative to the prefix (e.g., /subdir1/subdir2)
+                        let current_relative_dir = encoded_dir.trim_matches('/'); // Remove leading/trailing slashes if any
+                        
+                        // Combine the relative directory path and the filename
+                        let full_relative_path = if current_relative_dir.is_empty() {
+                            // If in the root directory, just use the filename
+                            utf8_percent_encode(&file_name, COMPONENT).to_string()
+                        } else {
+                            // Otherwise, join directory and filename
+                            format!(
+                                "{}/{}",
+                                current_relative_dir,
+                                utf8_percent_encode(&file_name, COMPONENT)
+                            )
+                        };
+                        
+                        // Join the external base URL with the full relative path
+                        format!(
+                            "{}/{}",
+                            base_url.trim_end_matches('/'), // Base URL without trailing slash
+                            full_relative_path // Relative path (dir + file) - should not have leading slash here
+                        )
+                    }
+                    None => {
+                        // Fallback to original relative URL generation
+                        base.join(utf8_percent_encode(&file_name, COMPONENT).to_string())
+                            .to_string_lossy()
+                            .to_string()
+                    }
+                };
+		    entries.push(Entry::new(
                         file_name.clone(),
                         EntryType::File,
-                        file_url,
+                        file_link,
                         Some(ByteSize::b(metadata.len())),
                         last_modification_date,
                         symlink_dest,

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -290,40 +290,40 @@ pub fn directory_listing(
                         symlink_dest,
                     ));
                 } else if metadata.is_file() {
-                let file_link = match &conf.file_base_url {
-                    Some(base_url) => {
-                        // Construct the full relative path including subdirectories
-                        // encoded_dir holds the current directory path relative to the prefix (e.g., /subdir1/subdir2)
-                        let current_relative_dir = encoded_dir.trim_matches('/'); // Remove leading/trailing slashes if any
-                        
-                        // Combine the relative directory path and the filename
-                        let full_relative_path = if current_relative_dir.is_empty() {
-                            // If in the root directory, just use the filename
-                            utf8_percent_encode(&file_name, COMPONENT).to_string()
-                        } else {
-                            // Otherwise, join directory and filename
+                    let file_link = match &conf.file_external_url {
+                        Some(external_url) => {
+                            // Construct the full relative path including subdirectories
+                            // encoded_dir holds the current directory path relative to the prefix (e.g., /subdir1/subdir2)
+                            let current_relative_dir = encoded_dir.trim_matches('/'); // Remove leading/trailing slashes if any
+
+                            // Combine the relative directory path and the filename
+                            let full_relative_path = if current_relative_dir.is_empty() {
+                                // If in the root directory, just use the filename
+                                utf8_percent_encode(&file_name, COMPONENT).to_string()
+                            } else {
+                                // Otherwise, join directory and filename
+                                format!(
+                                    "{}/{}",
+                                    current_relative_dir,
+                                    utf8_percent_encode(&file_name, COMPONENT)
+                                )
+                            };
+
+                            // Join the external external URL with the full relative path
                             format!(
                                 "{}/{}",
-                                current_relative_dir,
-                                utf8_percent_encode(&file_name, COMPONENT)
+                                external_url.trim_end_matches('/'), // Base URL without trailing slash
+                                full_relative_path // Relative path (dir + file) - should not have leading slash here
                             )
-                        };
-                        
-                        // Join the external base URL with the full relative path
-                        format!(
-                            "{}/{}",
-                            base_url.trim_end_matches('/'), // Base URL without trailing slash
-                            full_relative_path // Relative path (dir + file) - should not have leading slash here
-                        )
-                    }
-                    None => {
-                        // Fallback to original relative URL generation
-                        base.join(utf8_percent_encode(&file_name, COMPONENT).to_string())
-                            .to_string_lossy()
-                            .to_string()
-                    }
-                };
-		    entries.push(Entry::new(
+                        }
+                        None => {
+                            // Fallback to original relative URL generation
+                            base.join(utf8_percent_encode(&file_name, COMPONENT).to_string())
+                                .to_string_lossy()
+                                .to_string()
+                        }
+                    };
+                    entries.push(Entry::new(
                         file_name.clone(),
                         EntryType::File,
                         file_link,

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -316,12 +316,7 @@ pub fn directory_listing(
                                 full_relative_path // Relative path (dir + file) - should not have leading slash here
                             )
                         }
-                        None => {
-                            // Fallback to original relative URL generation
-                            base.join(utf8_percent_encode(&file_name, COMPONENT).to_string())
-                                .to_string_lossy()
-                                .to_string()
-                        }
+                        None => file_url,
                     };
                     entries.push(Entry::new(
                         file_name.clone(),

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1166,13 +1166,17 @@ mod tests {
         let expected = to_html("-nH -P '127.0.0.1:420' 'http://127.0.0.1:420");
         assert_eq!(to_be_tested, expected);
     }
-    
+
     #[test]
     fn test_wget_footer_externalurl() {
-        let to_be_tested: String =
-            wget_footer(&uri("https://github.com/"), None, None, Some("https://gitlab.com")).into();
+        let to_be_tested: String = wget_footer(
+            &uri("https://github.com/"),
+            None,
+            None,
+            Some("https://gitlab.com"),
+        )
+        .into();
         let expected = to_html("-H -P 'github.com' 'https://github.com");
         assert_eq!(to_be_tested, expected);
     }
-
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1111,7 +1111,7 @@ mod tests {
 
     #[test]
     fn test_wget_footer_trivial() {
-        let to_be_tested: String = wget_footer(&uri("https://github.com/"), None, None).into();
+        let to_be_tested: String = wget_footer(&uri("https://github.com/"), None, None, None).into();
         let expected = to_html("-P 'github.com' 'https://github.com");
         assert_eq!(to_be_tested, expected);
     }
@@ -1121,6 +1121,7 @@ mod tests {
         let to_be_tested: String = wget_footer(
             &uri("https://github.com/svenstaro/miniserve/"),
             Some("Miniserve"),
+            None,
             None,
         )
         .into();
@@ -1134,6 +1135,7 @@ mod tests {
             &uri("http://1und1.de/"),
             Some("1&1 - Willkommen!!!"),
             Some("Marcell D'Avis"),
+            None,
         )
         .into();
         let expected = to_html(
@@ -1148,6 +1150,7 @@ mod tests {
             &uri("http://127.0.0.1:1234/geheime_dokumente.php/"),
             Some("Streng Geheim!!!"),
             Some("uøý`¶'7ÅÛé"),
+            None,
         )
         .into();
         let expected = to_html(
@@ -1158,7 +1161,7 @@ mod tests {
 
     #[test]
     fn test_wget_footer_ip() {
-        let to_be_tested: String = wget_footer(&uri("http://127.0.0.1:420/"), None, None).into();
+        let to_be_tested: String = wget_footer(&uri("http://127.0.0.1:420/"), None, None, None).into();
         let expected = to_html("-P '127.0.0.1:420' 'http://127.0.0.1:420");
         assert_eq!(to_be_tested, expected);
     }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -24,7 +24,7 @@ fn api_dir_size(
     command.insert("DirSize", dir);
 
     let resp = Client::new()
-        .post(server.url().join(&format!("__miniserve_internal/api"))?)
+        .post(server.url().join(&"__miniserve_internal/api".to_string())?)
         .json(&command)
         .send()?
         .error_for_status()?;
@@ -54,7 +54,7 @@ fn api_dir_size_prevent_path_transversal_attacks(
     command.insert("DirSize", path);
 
     let resp = Client::new()
-        .post(server.url().join(&format!("__miniserve_internal/api"))?)
+        .post(server.url().join(&"__miniserve_internal/api".to_string())?)
         .json(&command)
         .send()?;
 

--- a/tests/raw.rs
+++ b/tests/raw.rs
@@ -48,7 +48,7 @@ fn ui_displays_wget_element(
     assert_eq!(
         wget_url,
         format!(
-            "wget -rcnHp -R 'index.html*'{} '{}{}?raw=true'",
+            "wget -rcnp -R 'index.html*' -nH{} '{}{}?raw=true'",
             cut_dirs,
             server.url(),
             dir


### PR DESCRIPTION
Adding an option to specify an absolute hostname to serve the files from somewhere else.

In my usecase, I wanted to have an authenticated instance for browsing and an unauthenticated one to serve files (with indexing disabled). Instead of having to rewrite the URL when sharing a link, this option would allow this without manual intervention. 