### PR TITLE
fix filtering symlinks in webdav methods

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -368,9 +368,7 @@ pub struct CliArgs {
     pub disable_indexing: bool,
 
     /// Enable read-only WebDAV support (PROPFIND requests)
-    ///
-    /// Currently incompatible with -P|--no-symlinks (see https://github.com/messense/dav-server-rs/issues/37)
-    #[arg(long, env = "MINISERVE_ENABLE_WEBDAV", conflicts_with = "no_symlinks")]
+    #[arg(long, env = "MINISERVE_ENABLE_WEBDAV")]
     pub enable_webdav: bool,
 
     /// Show served file size in exact bytes

--- a/src/main.rs
+++ b/src/main.rs
@@ -418,12 +418,12 @@ fn configure_app(app: &mut web::ServiceConfig, conf: &MiniserveConfig) {
     }
 
     if conf.webdav_enabled {
-        let fs = RestrictedFs::new(&conf.path, conf.show_hidden);
+        let fs = RestrictedFs::new(&conf.path, conf.show_hidden, conf.no_symlinks);
 
         let dav_server = DavHandler::builder()
             .filesystem(fs)
             .methods(DavMethodSet::WEBDAV_RO)
-            .hide_symlinks(conf.no_symlinks)
+            .hide_symlinks(false) // we handle filtering symlinks ourselves in RestrictedFs
             .strip_prefix(conf.route_prefix.to_owned())
             .build_handler();
 

--- a/src/webdav_fs.rs
+++ b/src/webdav_fs.rs
@@ -10,32 +10,77 @@ use dav_server::{
     },
     localfs::LocalFs,
 };
-use futures::{StreamExt, TryFutureExt, future::ready};
-use std::path::{Component, Path};
+use futures::StreamExt;
+use std::ffi::OsStr;
+#[cfg(target_family = "unix")]
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Component, Path, PathBuf};
+use tokio::fs;
 
 /// A dav_server local filesystem backend that can be configured to deny access
 /// to files and directories with names starting with a dot.
 #[derive(Clone)]
 pub struct RestrictedFs {
     local: Box<LocalFs>,
+    base_path: PathBuf,
     show_hidden: bool,
+    no_symlinks: bool,
 }
 
 impl RestrictedFs {
     /// Creates a new RestrictedFs serving the local path at "base".
     /// If "show_hidden" is false, access to hidden files is prevented.
-    pub fn new<P: AsRef<Path>>(base: P, show_hidden: bool) -> Box<RestrictedFs> {
+    /// If "no_symlinks" is true, access to symlinks is prevented.
+    pub fn new<P: AsRef<Path>>(base: P, show_hidden: bool, no_symlinks: bool) -> Box<RestrictedFs> {
+        let base_path = base.as_ref().to_path_buf();
         let local = LocalFs::new(base, false, false, false);
-        Box::new(RestrictedFs { local, show_hidden })
+        Box::new(RestrictedFs {
+            local,
+            base_path,
+            show_hidden,
+            no_symlinks,
+        })
+    }
+
+    /// true if the path is allowed to appear in responses (not hidden and/or not a symlink, depending on flags)
+    async fn is_path_allowed(&self, path: &DavPath) -> bool {
+        if self.no_symlinks && path_has_symlink_components(path, &self.base_path).await {
+            return false;
+        }
+        if !self.show_hidden && path_has_hidden_components(path) {
+            return false;
+        }
+        true
     }
 }
 
 /// true if any normal component of path either starts with dot or can't be turned into a str
 fn path_has_hidden_components(path: &DavPath) -> bool {
-    path.as_pathbuf().components().any(|c| match c {
+    path.as_rel_ospath().components().any(|c| match c {
         Component::Normal(name) => name.to_str().is_none_or(|s| s.starts_with('.')),
-        _ => false,
+        _ => panic!("dav path should not contain any non-normal components"),
     })
+}
+
+/// true if any component in `path` (relative to `base_path`) is a symlink
+async fn path_has_symlink_components(path: &DavPath, base_path: &Path) -> bool {
+    let mut current_path = base_path.to_path_buf();
+    for comp in path.as_rel_ospath().components() {
+        match comp {
+            Component::Normal(name) => {
+                current_path.push(name);
+                if let Ok(md) = fs::symlink_metadata(&current_path).await {
+                    if md.file_type().is_symlink() {
+                        return true;
+                    }
+                }
+            }
+            _ => {
+                panic!("dav path should not contain any non-normal components")
+            }
+        }
+    }
+    false
 }
 
 impl DavFileSystem for RestrictedFs {
@@ -44,11 +89,13 @@ impl DavFileSystem for RestrictedFs {
         path: &'a DavPath,
         options: DavOpenOptions,
     ) -> DavFsFuture<'a, Box<dyn DavFile>> {
-        if !path_has_hidden_components(path) || self.show_hidden {
-            self.local.open(path, options)
-        } else {
-            Box::pin(ready(Err(DavFsError::NotFound)))
-        }
+        Box::pin(async move {
+            if !self.is_path_allowed(path).await {
+                Err(DavFsError::NotFound)
+            } else {
+                self.local.open(path, options).await
+            }
+        })
     }
 
     fn read_dir<'a>(
@@ -56,37 +103,72 @@ impl DavFileSystem for RestrictedFs {
         path: &'a DavPath,
         meta: DavReadDirMeta,
     ) -> DavFsFuture<'a, DavFsStream<Box<dyn DavDirEntry>>> {
-        if self.show_hidden {
-            self.local.read_dir(path, meta)
-        } else if !path_has_hidden_components(path) {
-            Box::pin(self.local.read_dir(path, meta).map_ok(|stream| {
-                let dyn_stream: DavFsStream<Box<dyn DavDirEntry>> =
-                    Box::pin(stream.filter(|entry| {
-                        ready(match entry {
-                            Ok(e) => !e.name().starts_with(b"."),
-                            _ => false,
-                        })
-                    }));
-                dyn_stream
-            }))
-        } else {
-            Box::pin(ready(Err(DavFsError::NotFound)))
-        }
+        Box::pin(async move {
+            if !self.is_path_allowed(path).await {
+                return Err(DavFsError::NotFound);
+            }
+
+            if self.show_hidden && !self.no_symlinks {
+                return self.local.read_dir(path, meta).await;
+            }
+
+            let dav_path = path.as_rel_ospath();
+            let base_path = self.base_path.join(dav_path);
+            let show_hidden = self.show_hidden;
+            let no_symlinks = self.no_symlinks;
+
+            let stream = self.local.read_dir(path, meta).await?;
+
+            let filtered = stream.filter_map(move |entry_res| {
+                let base_path = base_path.clone();
+                async move {
+                    match entry_res {
+                        Ok(e) => {
+                            if !show_hidden && e.name().starts_with(b".") {
+                                return None;
+                            }
+                            if no_symlinks {
+                                let name = e.name();
+                                #[cfg(not(target_os = "windows"))]
+                                let os_string = OsStr::from_bytes(&name);
+                                #[cfg(target_os = "windows")]
+                                let os_string: &OsStr =
+                                    std::str::from_utf8(&name).unwrap().as_ref();
+                                let entry_path = base_path.join(os_string);
+                                if let Ok(md) = fs::symlink_metadata(&entry_path).await {
+                                    if md.file_type().is_symlink() {
+                                        return None;
+                                    }
+                                }
+                            }
+                            Some(Ok(e))
+                        }
+                        Err(e) => Some(Err(e)),
+                    }
+                }
+            });
+
+            Ok(Box::pin(filtered) as DavFsStream<Box<dyn DavDirEntry>>)
+        })
     }
 
     fn metadata<'a>(&'a self, path: &'a DavPath) -> DavFsFuture<'a, Box<dyn DavMetaData>> {
-        if !path_has_hidden_components(path) || self.show_hidden {
-            self.local.metadata(path)
-        } else {
-            Box::pin(ready(Err(DavFsError::NotFound)))
-        }
+        Box::pin(async move {
+            if !self.is_path_allowed(path).await {
+                Err(DavFsError::NotFound)
+            } else {
+                self.local.metadata(path).await
+            }
+        })
     }
 
     fn symlink_metadata<'a>(&'a self, path: &'a DavPath) -> DavFsFuture<'a, Box<dyn DavMetaData>> {
-        if !path_has_hidden_components(path) || self.show_hidden {
-            self.local.symlink_metadata(path)
-        } else {
-            Box::pin(ready(Err(DavFsError::NotFound)))
-        }
+        Box::pin(async move {
+            if !self.is_path_allowed(path).await {
+                Err(DavFsError::NotFound)
+            } else {
+                self.local.symlink_metadata(path).await
+            }
+        })
     }
 }

--- a/tests/webdav.rs
+++ b/tests/webdav.rs
@@ -13,7 +13,8 @@ use rstest::rstest;
 mod fixtures;
 
 use crate::fixtures::{
-    DIRECTORIES, DIRECTORY_SYMLINK, Error, FILE_SYMLINK, FILES, HIDDEN_DIRECTORIES, HIDDEN_FILES,
+    DIR_BEHIND_SYMLINKED_DIR, DIRECTORIES, DIRECTORY_SYMLINK, Error,
+    FILE_IN_DIR_BEHIND_SYMLINKED_DIR, FILE_SYMLINK, FILES, HIDDEN_DIRECTORIES, HIDDEN_FILES,
     TestServer, server, tmpdir,
 };
 
@@ -89,7 +90,6 @@ fn webdav_respects_hidden_flag(
 
 #[rstest]
 #[case(server(&["--enable-webdav"]), true)]
-#[should_panic]
 #[case(server(&["--enable-webdav", "--no-symlinks"]), false)]
 fn webdav_respects_no_symlink_flag(#[case] server: TestServer, #[case] symlinks_should_show: bool) {
     let list = list_webdav(server.url(), "/").unwrap();
@@ -109,8 +109,16 @@ fn webdav_respects_no_symlink_flag(#[case] server: TestServer, #[case] symlinks_
     );
 
     let list_linked = list_webdav(server.url(), &format!("/{}", DIRECTORY_SYMLINK));
-
     assert_eq!(symlinks_should_show, list_linked.is_ok());
+
+    let list_nested_dir = list_webdav(server.url(), &format!("/{}", DIR_BEHIND_SYMLINKED_DIR));
+    assert_eq!(symlinks_should_show, list_nested_dir.is_ok());
+
+    let list_nested_file = list_webdav(
+        server.url(),
+        &format!("/{}", FILE_IN_DIR_BEHIND_SYMLINKED_DIR),
+    );
+    assert_eq!(symlinks_should_show, list_nested_file.is_ok());
 }
 
 #[rstest]


### PR DESCRIPTION
This allows `--enable-webdav` and `--no-symlinks` to be used together, and adds the necessary filtering.