### PR TITLE
Minimalist search/filter feature

### DIFF
--- a/src/listing.rs
+++ b/src/listing.rs
@@ -47,6 +47,7 @@ pub struct ListingQueryParameters {
     pub sort: Option<SortingMethod>,
     pub order: Option<SortingOrder>,
     pub raw: Option<bool>,
+    pub search: Option<String>,
     download: Option<ArchiveMethod>,
 }
 
@@ -248,6 +249,13 @@ pub fn directory_listing(
     };
 
     let query_params = extract_query_parameters(req);
+    let search = query_params.search.as_ref().map(|s| s.to_lowercase());
+    let matches_search = move |filename: &str| -> bool {
+        match search {
+            Some(ref search) => filename.to_lowercase().contains(search),
+            None => true,
+        }
+    };
     let mut entries: Vec<Entry> = Vec::new();
     let mut readme: Option<(String, String)> = None;
     let readme_rx: Regex = Regex::new("^readme([.](md|txt))?$").unwrap();
@@ -257,6 +265,9 @@ pub fn directory_listing(
             let entry = entry?;
             // show file url as relative to static path
             let file_name = entry.file_name().to_string_lossy().to_string();
+            if !matches_search(&file_name) {
+                continue;
+            }
             let (is_symlink, metadata) = match entry.metadata() {
                 Ok(metadata) if metadata.file_type().is_symlink() => {
                     // for symlinks, get the metadata of the original file

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,4 +1,4 @@
-use std::time::SystemTime;
+use std::{borrow::Cow, time::SystemTime};
 
 use actix_web::http::{StatusCode, Uri};
 use chrono::{DateTime, Local};
@@ -30,14 +30,18 @@ pub fn page(
     conf: &MiniserveConfig,
     current_user: Option<&CurrentUser>,
 ) -> Markup {
+    let (sort_method, sort_order, search) = (
+        query_params.sort,
+        query_params.order,
+        query_params.search.as_deref(),
+    );
+
     // If query_params.raw is true, we want render a minimal directory listing
     if query_params.raw.is_some() && query_params.raw.unwrap() {
-        return raw(entries, is_root, conf);
+        return raw(entries, search, is_root, conf);
     }
 
     let upload_route = format!("{}/upload", &conf.route_prefix);
-    let (sort_method, sort_order) = (query_params.sort, query_params.order);
-
     let upload_action = build_upload_action(&upload_route, encoded_dir, sort_method, sort_order);
     let mkdir_action = build_mkdir_action(&upload_route, encoded_dir);
 
@@ -85,7 +89,7 @@ pub fn page(
                                 // wrapped in span so the text doesn't shift slightly when it turns into a link
                                 span { bdi { (el.name) } }
                             } @else {
-                                a href=(parametrized_link(&el.link, sort_method, sort_order, false)) {
+                                a href=(parametrized_link(&el.link, sort_method, sort_order, false, search)) {
                                     bdi { (el.name) }
                                 }
                             }
@@ -142,7 +146,7 @@ pub fn page(
                                     td colspan="3" {
                                         p {
                                             span.root-chevron { (chevron_left()) }
-                                            a.root href=(parametrized_link("../", sort_method, sort_order, false)) {
+                                            a.root href=(parametrized_link("../", sort_method, sort_order, false, search)) {
                                                 "Parent directory"
                                             }
                                         }
@@ -150,7 +154,7 @@ pub fn page(
                                 }
                             }
                             @for entry in entries {
-                                (entry_row(entry, sort_method, sort_order, false, conf.show_exact_bytes))
+                                (entry_row(entry, sort_method, sort_order, false, search, conf.show_exact_bytes))
                             }
                         }
                     }
@@ -215,7 +219,12 @@ pub fn page(
 }
 
 /// Renders the file listing
-pub fn raw(entries: Vec<Entry>, is_root: bool, conf: &MiniserveConfig) -> Markup {
+pub fn raw(
+    entries: Vec<Entry>,
+    search: Option<&str>,
+    is_root: bool,
+    conf: &MiniserveConfig,
+) -> Markup {
     html! {
         (DOCTYPE)
         html {
@@ -231,7 +240,7 @@ pub fn raw(entries: Vec<Entry>, is_root: bool, conf: &MiniserveConfig) -> Markup
                             tr {
                                 td colspan="3" {
                                     p {
-                                        a.root href=(parametrized_link("../", None, None, true)) {
+                                        a.root href=(parametrized_link("../", None, None, true, search)) {
                                             ".."
                                         }
                                     }
@@ -239,7 +248,7 @@ pub fn raw(entries: Vec<Entry>, is_root: bool, conf: &MiniserveConfig) -> Markup
                             }
                         }
                         @for entry in entries {
-                            (entry_row(entry, None, None, true, conf.show_exact_bytes))
+                            (entry_row(entry, None, None, true, search, conf.show_exact_bytes))
                         }
                     }
                 }
@@ -449,7 +458,7 @@ fn archive_button(
     } else {
         format!(
             "{}&download={}",
-            parametrized_link("", sort_method, sort_order, false),
+            parametrized_link("", sort_method, sort_order, false, None),
             archive_method
         )
     };
@@ -478,25 +487,34 @@ fn parametrized_link(
     sort_method: Option<SortingMethod>,
     sort_order: Option<SortingOrder>,
     raw: bool,
+    search: Option<&str>,
 ) -> String {
-    if raw {
-        return format!("{}?raw=true", make_link_with_trailing_slash(link));
-    }
+    let mut query: Vec<Cow<'static, str>> = Vec::with_capacity(4);
 
-    if let Some(method) = sort_method
+    if raw {
+        query.push("raw=true".into());
+    } else if let Some(method) = sort_method
         && let Some(order) = sort_order
     {
-        let parametrized_link = format!(
-            "{}?sort={}&order={}",
-            make_link_with_trailing_slash(link),
-            method,
-            order,
-        );
-
-        return parametrized_link;
+        query.push(format!("sort={method}").into());
+        query.push(format!("order={order}").into());
     }
 
-    make_link_with_trailing_slash(link)
+    if let Some(search) = search
+        && !search.is_empty()
+    {
+        query.push(format!("search={search}").into());
+    }
+
+    if query.is_empty() {
+        make_link_with_trailing_slash(link)
+    } else {
+        format!(
+            "{}?{}",
+            make_link_with_trailing_slash(link),
+            query.join("&")
+        )
+    }
 }
 
 /// Partial: table header link
@@ -538,6 +556,7 @@ fn entry_row(
     sort_method: Option<SortingMethod>,
     sort_order: Option<SortingOrder>,
     raw: bool,
+    search: Option<&str>,
     show_exact_bytes: bool,
 ) -> Markup {
     html! {
@@ -547,13 +566,13 @@ fn entry_row(
                 p {
                     @if entry.is_dir() {
                         @if let Some(ref symlink_dest) = entry.symlink_info {
-                            a.symlink href=(parametrized_link(&entry.link, sort_method, sort_order, raw)) {
+                            a.symlink href=(parametrized_link(&entry.link, sort_method, sort_order, raw, search)) {
                                 (entry.name) "/"
                                 span.symlink-symbol { }
                                 a.directory {(symlink_dest) "/"}
                             }
                         }@else {
-                            a.directory href=(parametrized_link(&entry.link, sort_method, sort_order, raw)) {
+                            a.directory href=(parametrized_link(&entry.link, sort_method, sort_order, raw, search)) {
                                 (entry.name) "/"
                             }
                         }


### PR DESCRIPTION
I recently needed a minimalist HTTP static file server, and I found that miniserve fits my needs very well.

However, it lacks a feature to filter by filename, which I really need. Coincidentally, Rust is a language I've been enjoying recently, so I tried adding this feature: add a `?search=xxx` query in url will filter output items by their filename.

This code is written purely based on my personal needs. For example, I don't need a search bar on the page, query parameters are sufficient for me...

I've already looked at the discussion in #62 and understand that search might not be a feature you want to add, so this PR doesn't need to be merged, you can close it if you want. I created it just so that the next user who tries to search for this feature can find a usable fork/branch with this feature and can continue from here if they want.

Thank you again for your beautiful work.

===

Screenshot:

Without filter:
![without filter](https://github.com/user-attachments/assets/f178599a-2e66-4461-aef8-bd5f70f878d9)

Without filter:
![with filter](https://github.com/user-attachments/assets/d2ebcbac-9a63-4f9c-bfd1-7ffa405d44a6)
