### PR TITLE
Use forward slashes in ZIP files; rewrite archive tests; refine error msg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ tempfile = "3.24.0"
 thiserror = "2"
 tokio = { version = "1.47.1", features = ["fs", "macros"] }
 zip = { version = "7", default-features = false }
-#zip = { path = "../zip2", default-features = false }
 
 [features]
 default = ["tls"]

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -251,37 +251,20 @@ where
             let current_entry_name = entry_path.file_name().ok_or_else(|| {
                 RuntimeError::InvalidPathError("Invalid file or directory name".to_string())
             })?;
-
-            // Workaround for Windows path in ZIP files:
-            // Always use forward slashes for all paths to avoid literal backslashes in saved entry path.
-            // TODO: remove this when the "zip" cargo has the ability to process a directory as a whole.
-            let relative_path = if cfg!(windows) {
-                let branch = zip_directory
-                    .as_os_str()
-                    .to_string_lossy()
-                    .trim_end_matches(r"\") // every branch ends with two backslashes "\\".
-                    .replace(r"\", "/"); // every branch uses backslash "\" as path separators.
-                let leaf = current_entry_name.to_string_lossy();
-                format!("{branch}/{leaf}") // construct a Unix-style path in the simplest way.
-            } else {
-                zip_directory
-                    .join(current_entry_name)
-                    .into_os_string()
-                    .to_string_lossy()
-                    .into_owned()
-            };
-
+            let relative_path = zip_directory.join(current_entry_name).into_os_string();
             if entry_metadata.is_file() {
                 let mut f = File::open(&entry_path)
                     .map_err(|e| RuntimeError::IoError("Could not open file".to_string(), e))?;
                 f.read_to_end(&mut buffer).map_err(|e| {
                     RuntimeError::IoError("Could not read from file".to_string(), e)
                 })?;
-                zip_writer.start_file(relative_path, options).map_err(|_| {
-                    RuntimeError::ArchiveCreationDetailError(
-                        "Could not add file path to ZIP".to_string(),
-                    )
-                })?;
+                zip_writer
+                    .start_file(relative_path.to_string_lossy(), options)
+                    .map_err(|_| {
+                        RuntimeError::ArchiveCreationDetailError(
+                            "Could not add file path to ZIP".to_string(),
+                        )
+                    })?;
                 zip_writer.write(buffer.as_ref()).map_err(|_| {
                     RuntimeError::ArchiveCreationDetailError(
                         "Could not write file to ZIP".to_string(),
@@ -290,7 +273,7 @@ where
                 buffer.clear();
             } else if entry_metadata.is_dir() {
                 zip_writer
-                    .add_directory(relative_path, options)
+                    .add_directory(relative_path.to_string_lossy(), options)
                     .map_err(|_| {
                         RuntimeError::ArchiveCreationDetailError(
                             "Could not add directory path to ZIP".to_string(),

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -253,7 +253,7 @@ where
             })?;
 
             // To let every software correctly parse the file structure in ZIP files that are produced
-            // on any platform (esp. Windows), always use backslashes. The documentation:
+            // on any platform (esp. Windows), always use forward slashes. The documentation:
             // https://users.cs.jmu.edu/buchhofp/forensics/formats/pkzip.html
             let relative_path = if cfg!(windows) {
                 let branch = zip_directory

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -243,20 +243,37 @@ where
             let current_entry_name = entry_path.file_name().ok_or_else(|| {
                 RuntimeError::InvalidPathError("Invalid file or directory name".to_string())
             })?;
+
+            // Workaround for Windows path in ZIP files:
+            //   Eliminate all backslashes to prevent the full relative paths from being saved as-is.
+            // XXX: remove this when the "zip" cargo has the ability to process a directory as a whole.
+            let relative_path = if cfg!(windows) {
+                let branch = zip_directory
+                    .as_os_str()
+                    .to_string_lossy()
+                    .trim_end_matches(r"\") // every branch ends with two backslashes "\\".
+                    .replace(r"\", "/"); // every branch uses backslash "\" as path separators.
+                let leaf = current_entry_name.to_string_lossy();
+                format!("{branch}/{leaf}") // construct a Unix-style path in the simplest way.
+            } else {
+                zip_directory
+                    .join(current_entry_name)
+                    .into_os_string()
+                    .to_string_lossy()
+                    .into_owned()
+            };
+
             if entry_metadata.is_file() {
                 let mut f = File::open(&entry_path)
                     .map_err(|e| RuntimeError::IoError("Could not open file".to_string(), e))?;
                 f.read_to_end(&mut buffer).map_err(|e| {
                     RuntimeError::IoError("Could not read from file".to_string(), e)
                 })?;
-                let relative_path = zip_directory.join(current_entry_name).into_os_string();
-                zip_writer
-                    .start_file(relative_path.to_string_lossy(), options)
-                    .map_err(|_| {
-                        RuntimeError::ArchiveCreationDetailError(
-                            "Could not add file path to ZIP".to_string(),
-                        )
-                    })?;
+                zip_writer.start_file(relative_path, options).map_err(|_| {
+                    RuntimeError::ArchiveCreationDetailError(
+                        "Could not add file path to ZIP".to_string(),
+                    )
+                })?;
                 zip_writer.write(buffer.as_ref()).map_err(|_| {
                     RuntimeError::ArchiveCreationDetailError(
                         "Could not write file to ZIP".to_string(),
@@ -264,9 +281,8 @@ where
                 })?;
                 buffer.clear();
             } else if entry_metadata.is_dir() {
-                let relative_path = zip_directory.join(current_entry_name).into_os_string();
                 zip_writer
-                    .add_directory(relative_path.to_string_lossy(), options)
+                    .add_directory(relative_path, options)
                     .map_err(|_| {
                         RuntimeError::ArchiveCreationDetailError(
                             "Could not add directory path to ZIP".to_string(),

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -155,7 +155,7 @@ where
         .map_err(|e| {
             RuntimeError::IoError(
                 format!(
-                    "Failed to append the content of '{}' to the TAR archive",
+                    "Failed to append the content of {} to the TAR archive",
                     src_dir.to_str().unwrap_or("file")
                 ),
                 e,
@@ -234,16 +234,8 @@ where
                     )
                 })?
                 .path();
-            let entry_metadata = std::fs::metadata(entry_path.clone()).map_err(|e| {
-                RuntimeError::IoError(
-                    format!(
-                        "Could not get file metadata of '{}'",
-                        entry_path.to_string_lossy()
-                    )
-                    .to_string(),
-                    e,
-                )
-            })?;
+            let entry_metadata = std::fs::metadata(entry_path.clone())
+                .map_err(|e| RuntimeError::IoError("Could not get file metadata".to_string(), e))?;
 
             if entry_metadata.file_type().is_symlink() && skip_symlinks {
                 continue;
@@ -251,37 +243,20 @@ where
             let current_entry_name = entry_path.file_name().ok_or_else(|| {
                 RuntimeError::InvalidPathError("Invalid file or directory name".to_string())
             })?;
-
-            // Workaround for Windows path in ZIP files:
-            //   Always use forward slashes for all paths to avoid literal backslashes in saved entry path.
-            // XXX: remove this when the "zip" cargo has the ability to process a directory as a whole.
-            let relative_path = if cfg!(windows) {
-                let branch = zip_directory
-                    .as_os_str()
-                    .to_string_lossy()
-                    .trim_end_matches(r"\") // every branch ends with two backslashes "\\".
-                    .replace(r"\", "/"); // every branch uses backslash "\" as path separators.
-                let leaf = current_entry_name.to_string_lossy();
-                format!("{branch}/{leaf}") // construct a Unix-style path in the simplest way.
-            } else {
-                zip_directory
-                    .join(current_entry_name)
-                    .into_os_string()
-                    .to_string_lossy()
-                    .into_owned()
-            };
-
             if entry_metadata.is_file() {
                 let mut f = File::open(&entry_path)
                     .map_err(|e| RuntimeError::IoError("Could not open file".to_string(), e))?;
                 f.read_to_end(&mut buffer).map_err(|e| {
                     RuntimeError::IoError("Could not read from file".to_string(), e)
                 })?;
-                zip_writer.start_file(relative_path, options).map_err(|_| {
-                    RuntimeError::ArchiveCreationDetailError(
-                        "Could not add file path to ZIP".to_string(),
-                    )
-                })?;
+                let relative_path = zip_directory.join(current_entry_name).into_os_string();
+                zip_writer
+                    .start_file(relative_path.to_string_lossy(), options)
+                    .map_err(|_| {
+                        RuntimeError::ArchiveCreationDetailError(
+                            "Could not add file path to ZIP".to_string(),
+                        )
+                    })?;
                 zip_writer.write(buffer.as_ref()).map_err(|_| {
                     RuntimeError::ArchiveCreationDetailError(
                         "Could not write file to ZIP".to_string(),
@@ -289,8 +264,9 @@ where
                 })?;
                 buffer.clear();
             } else if entry_metadata.is_dir() {
+                let relative_path = zip_directory.join(current_entry_name).into_os_string();
                 zip_writer
-                    .add_directory(relative_path, options)
+                    .add_directory(relative_path.to_string_lossy(), options)
                     .map_err(|_| {
                         RuntimeError::ArchiveCreationDetailError(
                             "Could not add directory path to ZIP".to_string(),

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -155,7 +155,7 @@ where
         .map_err(|e| {
             RuntimeError::IoError(
                 format!(
-                    "Failed to append the content of {} to the TAR archive",
+                    "Failed to append the content of '{}' to the TAR archive",
                     src_dir.to_str().unwrap_or("file")
                 ),
                 e,
@@ -234,8 +234,16 @@ where
                     )
                 })?
                 .path();
-            let entry_metadata = std::fs::metadata(entry_path.clone())
-                .map_err(|e| RuntimeError::IoError("Could not get file metadata".to_string(), e))?;
+            let entry_metadata = std::fs::metadata(entry_path.clone()).map_err(|e| {
+                RuntimeError::IoError(
+                    format!(
+                        "Could not get file metadata of '{}'",
+                        entry_path.to_string_lossy()
+                    )
+                    .to_string(),
+                    e,
+                )
+            })?;
 
             if entry_metadata.file_type().is_symlink() && skip_symlinks {
                 continue;
@@ -243,20 +251,37 @@ where
             let current_entry_name = entry_path.file_name().ok_or_else(|| {
                 RuntimeError::InvalidPathError("Invalid file or directory name".to_string())
             })?;
+
+            // Workaround for Windows path in ZIP files:
+            //   Always use forward slashes for all paths to avoid literal backslashes in saved entry path.
+            // XXX: remove this when the "zip" cargo has the ability to process a directory as a whole.
+            let relative_path = if cfg!(windows) {
+                let branch = zip_directory
+                    .as_os_str()
+                    .to_string_lossy()
+                    .trim_end_matches(r"\") // every branch ends with two backslashes "\\".
+                    .replace(r"\", "/"); // every branch uses backslash "\" as path separators.
+                let leaf = current_entry_name.to_string_lossy();
+                format!("{branch}/{leaf}") // construct a Unix-style path in the simplest way.
+            } else {
+                zip_directory
+                    .join(current_entry_name)
+                    .into_os_string()
+                    .to_string_lossy()
+                    .into_owned()
+            };
+
             if entry_metadata.is_file() {
                 let mut f = File::open(&entry_path)
                     .map_err(|e| RuntimeError::IoError("Could not open file".to_string(), e))?;
                 f.read_to_end(&mut buffer).map_err(|e| {
                     RuntimeError::IoError("Could not read from file".to_string(), e)
                 })?;
-                let relative_path = zip_directory.join(current_entry_name).into_os_string();
-                zip_writer
-                    .start_file(relative_path.to_string_lossy(), options)
-                    .map_err(|_| {
-                        RuntimeError::ArchiveCreationDetailError(
-                            "Could not add file path to ZIP".to_string(),
-                        )
-                    })?;
+                zip_writer.start_file(relative_path, options).map_err(|_| {
+                    RuntimeError::ArchiveCreationDetailError(
+                        "Could not add file path to ZIP".to_string(),
+                    )
+                })?;
                 zip_writer.write(buffer.as_ref()).map_err(|_| {
                     RuntimeError::ArchiveCreationDetailError(
                         "Could not write file to ZIP".to_string(),
@@ -264,9 +289,8 @@ where
                 })?;
                 buffer.clear();
             } else if entry_metadata.is_dir() {
-                let relative_path = zip_directory.join(current_entry_name).into_os_string();
                 zip_writer
-                    .add_directory(relative_path.to_string_lossy(), options)
+                    .add_directory(relative_path, options)
                     .map_err(|_| {
                         RuntimeError::ArchiveCreationDetailError(
                             "Could not add directory path to ZIP".to_string(),

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -253,8 +253,8 @@ where
             })?;
 
             // Workaround for Windows path in ZIP files:
-            //   Always use forward slashes for all paths to avoid literal backslashes in saved entry path.
-            // XXX: remove this when the "zip" cargo has the ability to process a directory as a whole.
+            // Always use forward slashes for all paths to avoid literal backslashes in saved entry path.
+            // TODO: remove this when the "zip" cargo has the ability to process a directory as a whole.
             let relative_path = if cfg!(windows) {
                 let branch = zip_directory
                     .as_os_str()

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -1,6 +1,9 @@
+use std::io::Cursor;
+
 use reqwest::{StatusCode, blocking::Client};
 use rstest::rstest;
 use select::{document::Document, predicate::Text};
+use zip::ZipArchive;
 
 mod fixtures;
 
@@ -229,6 +232,35 @@ fn archive_behave_differently_with_broken_symlinks(
     match expected {
         ExpectedLen::Exact(len) => assert_eq!(byte_len, len),
         ExpectedLen::Min(len) => assert!(byte_len >= len),
+    }
+
+    Ok(())
+}
+
+/// ZIP archives store entry names using unix-style paths (no backslashes).
+/// The "someDir" dir is constructed by [`fixtures`] and all items in it can be correctly processed.
+#[rstest]
+fn zip_archives_store_entry_name_in_unix_style(
+    #[with(&["--enable-zip"])] server: TestServer,
+    reqwest_client: Client,
+) -> Result<(), Error> {
+    let resp = reqwest_client
+        .get(server.url().join("someDir/?download=zip")?)
+        .send()?
+        .error_for_status()?;
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let mut archive = ZipArchive::new(Cursor::new(resp.bytes()?))?;
+    for i in 0..archive.len() {
+        let entry = archive.by_index(i)?;
+        let name = entry.name();
+
+        assert!(
+            !name.contains(r"\"),
+            "ZIP entry '{}' contains a backslash",
+            name
+        );
     }
 
     Ok(())

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -71,16 +71,14 @@ fn assert_link_presence(document: &Document, present: &[&str], absent: &[&str]) 
     for text in present {
         assert!(
             contains_text(document, text),
-            "Expected link text '{}' to be present",
-            text
+            "Expected link text '{text}' to be present",
         );
     }
 
     for text in absent {
         assert!(
             !contains_text(document, text),
-            "Expected link text '{}' to be absent",
-            text
+            "Expected link text '{text}' to be absent",
         );
     }
 }

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -1,7 +1,8 @@
+use std::io::Cursor;
+
 use reqwest::{StatusCode, blocking::Client};
 use rstest::rstest;
 use select::{document::Document, predicate::Text};
-use std::io::Cursor;
 use zip::ZipArchive;
 
 mod fixtures;
@@ -50,10 +51,10 @@ fn archives_are_disabled(server: TestServer, reqwest_client: Client) -> Result<(
 
 #[rstest]
 fn test_tar_archives(
-    #[with(&["-g"])] server: TestServer,
+    #[with(&["--enable-tar-gz"])] server: TestServer,
     reqwest_client: Client,
 ) -> Result<(), Error> {
-    // Ensure the links to the tar.gz archive exists and tar and zip not exists
+    // Ensure the links to the tar.gz archive exists and tar and zip do not exist
     let body = reqwest_client
         .get(server.url())
         .send()?

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -110,25 +110,22 @@ fn archive_behave_differently_with_broken_symlinks(
     };
 
     // Produce a file with only partial header fields. See "rfc1952 § 2.3.1. Member header and trailer".
-    // ArchiveCreationError("tarball", IoError("Failed to append the content of ... to the TAR archive",
-    //   Os { code: 1921, kind: FilesystemLoop, message: "The name of the file cannot be resolved by the system." }))
+    // ArchiveCreationError("tarball", IoError("Failed to append the content of ... to the TAR archive"
     {
         let bytes = download_archive("tar_gz");
         assert_eq!(bytes.len(), 10);
     }
 
-    // Produce an incomplete file
-    // ArchiveCreationError("tarball", IoError("Failed to append the content of ... to the TAR archive",
-    //   Os { code: 1921, kind: FilesystemLoop, message: "The name of the file cannot be resolved by the system." }))
+    // Produce a tarball containing a subset of files
+    // ArchiveCreationError("tarball", IoError("Failed to append the content of ... to the TAR archive"
     {
         let bytes = download_archive("tar");
-        assert_eq!(bytes.len(), 51200);
+        assert!(bytes.len() >= 512 + 512 + 2 * 512); // at least: header block + data + end marker
     }
 
     // Produce an empty file
     // Error during archive creation: ArchiveCreationError("zip", ArchiveCreationError(
-    //   "Failed to create the ZIP archive", IoError("Could not get file metadata ...",
-    //   Os { code: 1921, kind: FilesystemLoop, message: "The name of the file cannot be resolved by the system." })))
+    //   "Failed to create the ZIP archive", IoError("Could not get file metadata ..."
     {
         let bytes = download_archive("zip");
         assert_eq!(bytes.len(), 0);

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -1,6 +1,8 @@
 use reqwest::StatusCode;
 use rstest::rstest;
 use select::{document::Document, predicate::Text};
+use std::io::Cursor;
+use zip;
 
 mod fixtures;
 
@@ -87,6 +89,73 @@ fn archives_are_disabled_when_indexing_disabled(
         reqwest::blocking::get(server.url().join("?download=zip")?)?.status(),
         StatusCode::NOT_FOUND
     );
+
+    Ok(())
+}
+
+#[rstest]
+fn archive_behave_differently_with_broken_symlinks(
+    #[with(&["--enable-tar-gz", "--enable-tar", "--enable-zip"])] server: TestServer,
+) -> Result<(), Error> {
+    let download_archive = |download_type: &str| {
+        let body = reqwest::blocking::get(
+            server
+                .url()
+                .join(format!("?download={}", download_type).as_str())
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(body.status(), StatusCode::OK);
+        body.bytes().unwrap()
+    };
+
+    // Produce a file with only partial header fields. See "rfc1952 § 2.3.1. Member header and trailer".
+    // ArchiveCreationError("tarball", IoError("Failed to append the content of ... to the TAR archive",
+    //   Os { code: 1921, kind: FilesystemLoop, message: "The name of the file cannot be resolved by the system." }))
+    {
+        let bytes = download_archive("tar_gz");
+        assert_eq!(bytes.len(), 10);
+    }
+
+    // Produce an incomplete file
+    // ArchiveCreationError("tarball", IoError("Failed to append the content of ... to the TAR archive",
+    //   Os { code: 1921, kind: FilesystemLoop, message: "The name of the file cannot be resolved by the system." }))
+    {
+        let bytes = download_archive("tar");
+        assert_eq!(bytes.len(), 51200);
+    }
+
+    // Produce an empty file
+    // Error during archive creation: ArchiveCreationError("zip", ArchiveCreationError(
+    //   "Failed to create the ZIP archive", IoError("Could not get file metadata ...",
+    //   Os { code: 1921, kind: FilesystemLoop, message: "The name of the file cannot be resolved by the system." })))
+    {
+        let bytes = download_archive("zip");
+        assert_eq!(bytes.len(), 0);
+    }
+
+    Ok(())
+}
+
+#[rstest]
+fn zip_archives_store_entry_name_in_unix_style(
+    #[with(&["--enable-zip"])] server: TestServer,
+) -> Result<(), Error> {
+    let body = reqwest::blocking::get(server.url().join("someDir/?download=zip")?)?;
+    assert_eq!(body.status(), StatusCode::OK);
+
+    let mut archive = zip::ZipArchive::new(Cursor::new(body.bytes()?))?;
+    for i in 0..archive.len() {
+        let entry = archive.by_index(i)?;
+        let name = entry.name();
+
+        // Assert that the name does not contain any backslashes
+        assert!(
+            !name.contains(r"\"),
+            "ZIP entry '{}' contains a backslash",
+            name
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Hello!

I'm running miniserve on Windows. I found that my files in produced ZIP files cannot be correctly extracted on macOS, but Windows Explorer didn't complain about it. After reading a post [^superuser-1382839], I thought I can fix it. Now here's the PR.

[^superuser-1382839]: windows - Zip files expand with backslashes on Linux, no subdirectories - Super User - https://superuser.com/q/1382839

I'm new to Rust. Please review my code and help me correct anything wrong.

My test. Run it on Git Bash (untested on WSL):

<details>
<summary>Bash shell script</summary>

```bash
#!/bin/bash

set -eu

# positional args
PORT=${1:-8080}

command -v miniserve 2>/dev/null || (echo 'miniserve not found' && exit 1)

playground="$(TMPDIR="$PWD" mktemp -d --suffix="-$(TZ='UTC' date '+%Y%m%dT%H%M%SZ')")"
wwwroot_dir="$playground/wwwroot"
downloaded_dir="$playground/download"
downloaded_file="$downloaded_dir/download.zip"

mkdir -p "$wwwroot_dir" "$downloaded_dir"

for name in 'out' 'out_dir/mid' 'out_dir/mid_dir/in'; do
    mkdir -p "$wwwroot_dir/${name}_dir"
    touch "$wwwroot_dir/${name}_file"
    dd if=/dev/urandom of="$wwwroot_dir/${name}_file" count=10 status=none
done

miniserve "$wwwroot_dir" --port $PORT --interfaces 127.0.0.1 --enable-zip &
pid=$!

curl -s -L "http://127.0.0.1:$PORT/?download=zip" -o "$downloaded_file"

kill $pid

unzip -l "$downloaded_file"

```

</details>

The output before this PR:

```
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  1980-01-01 00:00   wwwroot\out_dir/
     5120  1980-01-01 00:00   wwwroot\out_file
        0  1980-01-01 00:00   wwwroot\out_dir\mid_dir/
     5120  1980-01-01 00:00   wwwroot\out_dir\mid_file
        0  1980-01-01 00:00   wwwroot\out_dir\mid_dir\in_dir/
     5120  1980-01-01 00:00   wwwroot\out_dir\mid_dir\in_file
---------                     -------
    15360                     6 files

```

The output for now:

```
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  1980-01-01 00:00   wwwroot/out_dir/
     5120  1980-01-01 00:00   wwwroot/out_file
        0  1980-01-01 00:00   wwwroot/out_dir/mid_dir/
     5120  1980-01-01 00:00   wwwroot/out_dir/mid_file
        0  1980-01-01 00:00   wwwroot/out_dir/mid_dir/in_dir/
     5120  1980-01-01 00:00   wwwroot/out_dir/mid_dir/in_file
---------                     -------
    15360                     6 files

```

Before applying this fix, third-party archive utilities, for example PeaZip and 7-Zip, can't understand those backslashes:

<img height="400" alt="Screenshot of the incorrect directory layout in 3rd-party archive utility PeaZip and 7-Zip" src="https://github.com/user-attachments/assets/9dc25fb2-6e1d-4425-8826-53d0f9a4367f" />

However, Windows Explorer always shows the correct directory hierarchy despite this fix:

<img height="172" alt="Screenshot of a multi-layer directory layout in the sidebar of Windows Explorer" src="https://github.com/user-attachments/assets/d589aa29-3074-4366-b9ec-44694aeb7ecd" />

.