### PR TITLE
Fix missing UTF-8 charset on text file responses

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,10 +7,15 @@ use actix_files::NamedFile;
 use actix_web::middleware::from_fn;
 use actix_web::{
     App, HttpRequest, HttpResponse, Responder,
+    body::MessageBody,
     dev::{ServiceRequest, ServiceResponse, fn_service},
     guard,
-    http::{Method, header::ContentType},
-    middleware, web,
+    http::{
+        Method,
+        header::{self, ContentType},
+    },
+    middleware::{self, Next},
+    web,
 };
 use actix_web_httpauth::middleware::HttpAuthentication;
 use anyhow::Result;
@@ -259,6 +264,7 @@ async fn run(miniserve_config: MiniserveConfig) -> Result<(), StartupError> {
             .route(&inside_config.css_route, web::get().to(css))
             .service(
                 web::scope(&inside_config.route_prefix)
+                    .wrap(from_fn(ensure_utf8_text_content_type))
                     .wrap(middleware::Condition::new(
                         !inside_config.auth.is_empty(),
                         actix_web::middleware::Compat::new(HttpAuthentication::basic(
@@ -352,6 +358,28 @@ fn configure_header(conf: &MiniserveConfig) -> middleware::DefaultHeaders {
         middleware::DefaultHeaders::new(),
         |headers, (header_name, header_value)| headers.add((header_name, header_value)),
     )
+}
+
+/// Add a UTF-8 charset to text responses that don't already declare one.
+async fn ensure_utf8_text_content_type(
+    req: ServiceRequest,
+    next: Next<impl MessageBody + 'static>,
+) -> Result<ServiceResponse<impl MessageBody>, actix_web::Error> {
+    let mut response = next.call(req).await?;
+
+    if let Some(content_type) = response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<mime::Mime>().ok())
+        && content_type.type_() == mime::TEXT
+        && content_type.get_param(mime::CHARSET).is_none()
+        && let Ok(value) = header::HeaderValue::from_str(&format!("{content_type}; charset=utf-8"))
+    {
+        response.headers_mut().insert(header::CONTENT_TYPE, value);
+    }
+
+    Ok(response)
 }
 
 /// Configures the Actix application

--- a/tests/encoding.rs
+++ b/tests/encoding.rs
@@ -1,0 +1,46 @@
+use std::fs;
+
+use reqwest::blocking::Client;
+use reqwest::header::CONTENT_TYPE;
+use rstest::rstest;
+
+mod fixtures;
+
+use crate::fixtures::{Error, TestServer, reqwest_client, server};
+
+fn write_utf8_file(server: &TestServer, filename: &str) {
+    fs::write(server.path().join(filename), "你好，miniserve\n")
+        .expect("Couldn't write UTF-8 test file");
+}
+
+#[rstest]
+#[case("test.txt", "text/plain; charset=utf-8")]
+#[case("test.js", "text/javascript; charset=utf-8")]
+#[case("README.md", "text/markdown; charset=utf-8")]
+fn served_text_files_include_utf8_charset(
+    server: TestServer,
+    reqwest_client: Client,
+    #[case] filename: &str,
+    #[case] expected_content_type: &str,
+) -> Result<(), Error> {
+    write_utf8_file(&server, filename);
+
+    let response = reqwest_client
+        .get(server.url().join(filename)?)
+        .send()?
+        .error_for_status()?;
+
+    assert_eq!(
+        response
+            .headers()
+            .get(CONTENT_TYPE)
+            .expect("Expected Content-Type header")
+            .to_str()?,
+        expected_content_type,
+    );
+
+    let body = response.text()?;
+    assert!(body.contains("你好，miniserve"));
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #1500.

`actix-files` is currently only appending `charset=utf-8` to some text responses, so UTF-8 `.js` and `.md` files are still served without a charset while `.txt` already gets one.

This adds a small response middleware on the file-serving scope that appends `charset=utf-8` to `text/*` responses that don't already declare a charset.

Validation:
- cargo test served_text_files_include_utf8_charset --test encoding -- --nocapture
- cargo test --test serve_request
- cargo fmt --check
