### PR TITLE
Use current datetime instead of "crypto.randomUUID()" in non-HTTPS env

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1183,7 +1183,13 @@ fn page_header(
                             const title = ((inputValue) => {
                                 const title = inputValue.trim();
                                 if (title.length === 0) {
-                                    const suffix = crypto.randomUUID().substring(0,6);
+                                    let suffix;
+                                    if (crypto.randomUUID !== undefined) {
+                                        suffix = crypto.randomUUID().substring(0,6);
+                                    } else {
+                                        // neither HTTPS nor "localhost"
+                                        suffix = Date.now().toString(16).slice(-6);
+                                    }
                                     return `paste-${suffix}.txt`;
                                 } else {
                                     // use given extension if one is present, otherwise make it


### PR DESCRIPTION
Hi.

The reason:

> Secure context: This feature is available only in secure contexts
> (HTTPS), in some or all supporting browsers.
>
> *from: https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID*

The environment:

- Windows 11 (Version 10.0.22631.4317)
- Microsoft Edge Version 147.0.3912.72 (Official build) (64-bit)

The command:

```bash
$ ./miniserve-0.35.0-x86_64-pc-windows-msvc.exe \
  --interfaces '192.168.1.2' \
  --interfaces '127.0.0.1' \
  --pastebin \
  --upload-files '.' \
  --verbose \
  '.'

```

The console when I was using pastebin in `http://192.168.1.2/`:

```
00:00:00.000 ?sort=date&order=desc:412 Uncaught TypeError: crypto.randomUUID is not a function
    at ?sort=date&order=desc:412:59
    at HTMLFormElement.<anonymous> (?sort=date&order=desc:424:31)

```

Then no file was uploaded until I specified a name.

The error did not appear when I was in `http://127.0.0.1/`.

