### PR TITLE
Implement `--inline` flag to serve files inline (`content-disposition:inline`)

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -383,7 +383,7 @@ pub struct CliArgs {
     ///
     /// Example:
     /// miniserve --inline sample.pdf
-    #[arg(short = 'i', long = "inline", env = "MINISERVE_INLINE")]
+    #[arg(long = "inline", env = "MINISERVE_INLINE")]
     pub inline: bool,
 
     /// Visualize symlinks in directory listing

--- a/src/args.rs
+++ b/src/args.rs
@@ -376,6 +376,16 @@ pub struct CliArgs {
     )]
     pub header: Vec<HeaderMap>,
 
+    /// Serve files inline in the browser instead of triggering a download.
+    ///
+    /// Useful when serving files that can be rendered directly by the browser (e.g., PDFs,
+    /// images, or text files).
+    ///
+    /// Example:
+    /// miniserve --inline sample.pdf
+    #[arg(short = 'i', long = "inline", env = "MINISERVE_INLINE")]
+    pub inline: bool,
+
     /// Visualize symlinks in directory listing
     #[arg(
         short = 'l',

--- a/src/config.rs
+++ b/src/config.rs
@@ -164,6 +164,9 @@ pub struct MiniserveConfig {
     /// Shown instead of host in page title and heading
     pub title: Option<String>,
 
+    /// If enabled, serve files inline with `Content-Disposition: inline`
+    pub inline: bool,
+
     /// If specified, header will be added
     pub header: Vec<HeaderMap>,
 
@@ -369,6 +372,7 @@ impl MiniserveConfig {
             zip_enabled: args.enable_zip,
             dirs_first: args.dirs_first,
             title: args.title,
+            inline: args.inline,
             header: args.header,
             show_symlink_info: args.show_symlink_info,
             hide_version_footer: args.hide_version_footer,

--- a/src/listing.rs
+++ b/src/listing.rs
@@ -4,7 +4,14 @@ use std::path::{Component, Path};
 use std::time::SystemTime;
 
 use actix_web::{
-    HttpMessage, HttpRequest, HttpResponse, dev::ServiceResponse, http::Uri, web, web::Query,
+    HttpMessage, HttpRequest, HttpResponse,
+    dev::ServiceResponse,
+    http::{
+        Uri,
+        header::{ContentDisposition, DispositionType},
+    },
+    web,
+    web::Query,
 };
 use bytesize::ByteSize;
 use clap::ValueEnum;
@@ -163,7 +170,24 @@ pub async fn file_handler(req: HttpRequest) -> actix_web::Result<actix_files::Na
         .app_data::<web::Data<crate::MiniserveConfig>>()
         .unwrap()
         .path;
-    actix_files::NamedFile::open(path).map_err(Into::into)
+    let file = actix_files::NamedFile::open(path).map_err(Into::into);
+
+    match file {
+        Ok(file) => {
+            let conf = req.app_data::<web::Data<crate::MiniserveConfig>>().unwrap();
+            if !conf.inline {
+                return Ok(file);
+            }
+
+            let cd = file.content_disposition().clone();
+
+            Ok(file.set_content_disposition(ContentDisposition {
+                disposition: DispositionType::Inline,
+                parameters: cd.parameters,
+            }))
+        }
+        Err(err) => Err(err),
+    }
 }
 
 /// List a directory and renders a HTML file accordingly

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::thread;
 use std::time::Duration;
 
 use actix_files::NamedFile;
-use actix_web::http::header::DispositionType;
+use actix_web::http::header::{CONTENT_DISPOSITION, DispositionType};
 use actix_web::middleware::from_fn;
 use actix_web::{
     App, HttpRequest, HttpResponse, Responder,
@@ -116,6 +116,18 @@ async fn run(miniserve_config: MiniserveConfig) -> Result<(), StartupError> {
     )
     .or_else(|_| simplelog::SimpleLogger::init(log_level, simplelog::Config::default()))
     .expect("Couldn't initialize logger");
+
+    if !miniserve_config.quiet
+        && miniserve_config
+            .header
+            .iter()
+            .any(|header_map| header_map.contains_key(CONTENT_DISPOSITION))
+    {
+        warn!(
+            "`Content-Disposition` headers specified via `--header` are ignored because miniserve handles content disposition automatically. ",
+        );
+        warn!("Use the `--inline` flag if you want files to be served inline in the browser.");
+    }
 
     if miniserve_config.no_symlinks && miniserve_config.path.is_symlink() {
         return Err(StartupError::NoSymlinksOptionWithSymlinkServePath(

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::thread;
 use std::time::Duration;
 
 use actix_files::NamedFile;
+use actix_web::http::header::DispositionType;
 use actix_web::middleware::from_fn;
 use actix_web::{
     App, HttpRequest, HttpResponse, Responder,
@@ -404,6 +405,10 @@ fn configure_app(app: &mut web::ServiceConfig, conf: &MiniserveConfig) {
 
         if conf.show_hidden {
             files = files.use_hidden_files();
+        }
+
+        if conf.inline {
+            files = files.mime_override(|_| DispositionType::Inline);
         }
 
         let base_path = conf.path.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ async fn run(miniserve_config: MiniserveConfig) -> Result<(), StartupError> {
             .any(|header_map| header_map.contains_key(CONTENT_DISPOSITION))
     {
         warn!(
-            "`Content-Disposition` headers specified via `--header` are ignored because miniserve handles content disposition automatically. ",
+            "`Content-Disposition` headers specified via `--header` are ignored because miniserve handles content disposition automatically.",
         );
         warn!("Use the `--inline` flag if you want files to be served inline in the browser.");
     }

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -150,10 +150,25 @@ where
     I: IntoIterator + Clone,
     I::Item: AsRef<std::ffi::OsStr>,
 {
+    server_with_path(args, "")
+}
+
+/// Run miniserve as a server serving a specific path relative to the temporary directory.
+#[fixture]
+pub fn server_with_path<I>(
+    #[default(&[] as &[&str])] args: I,
+    #[default("😀.data")] path: &str,
+) -> TestServer
+where
+    I: IntoIterator + Clone,
+    I::Item: AsRef<std::ffi::OsStr>,
+{
     let port = port();
     let tmpdir = tmpdir();
+    let serve_path = tmpdir.path().join(path);
+
     let mut child = Command::new(cargo::cargo_bin!("miniserve"))
-        .arg(tmpdir.path())
+        .arg(&serve_path)
         .arg("-v")
         .arg("-p")
         .arg(port.to_string())

--- a/tests/serve_request.rs
+++ b/tests/serve_request.rs
@@ -20,7 +20,7 @@ mod fixtures;
 use crate::fixtures::{
     DIR_BEHIND_SYMLINKED_DIR, DIRECTORIES, DIRECTORY_SYMLINK, Error,
     FILE_IN_DIR_BEHIND_SYMLINKED_DIR, FILE_SYMLINK, FILES, HIDDEN_DIRECTORIES, HIDDEN_FILES,
-    TestServer, port, reqwest_client, server, tmpdir,
+    TestServer, port, reqwest_client, server, server_with_path, tmpdir,
 };
 
 #[rstest]
@@ -533,6 +533,42 @@ fn serves_file_requests_when_indexing_disabled(
         .get(format!("{}{}", server.url(), FILES[0]))
         .send()?
         .error_for_status()?;
+
+    Ok(())
+}
+
+#[rstest]
+fn inline_header_set_directory(reqwest_client: Client) -> Result<(), Error> {
+    let server_inline = server(vec!["--inline"]);
+    let resp_inline = reqwest_client
+        .get(server_inline.url().join("😀.data").unwrap())
+        .send()?;
+    let cd = String::from_utf8_lossy(
+        resp_inline
+            .headers()
+            .get("content-disposition")
+            .unwrap()
+            .as_bytes(),
+    );
+    assert!(cd.starts_with("inline"));
+
+    Ok(())
+}
+
+#[rstest]
+fn inline_header_set_single_file(
+    #[with(vec!["--inline"], "😀.data")] server_with_path: TestServer,
+    reqwest_client: Client,
+) -> Result<(), Error> {
+    let resp_inline = reqwest_client.get(server_with_path.url()).send()?;
+    let cd = String::from_utf8_lossy(
+        resp_inline
+            .headers()
+            .get("content-disposition")
+            .unwrap()
+            .as_bytes(),
+    );
+    assert!(cd.starts_with("inline"));
 
     Ok(())
 }


### PR DESCRIPTION
Closes #1564.

# Description

This PR implements a new `--inline` command-line flag to serve files with `Content-Disposition: inline` instead of the default `Content-Disposition: attachment`.

This allows web browsers to render supported files (such as PDFs, images, or text files) directly in the browser instead of forcing a download.

- With `--inline`:
  ```bash
  http head http://localhost:8080/sample.pdf
  ╭───┬─────────────────────┬───────────────────────────────╮
  │ # │        name         │             value             │
  ├───┼─────────────────────┼───────────────────────────────┤
  │ 0 │ content-type        │ application/pdf               │
  │ 1 │ content-disposition │ inline; filename="sample.pdf" │
  │ 2 │ ...                 │ [truncated]                   │
  ╰───┴─────────────────────┴───────────────────────────────╯
  ```
- Default (without `--inline`):
  ```bash
  http head http://localhost:8080/sample.pdf
  ╭───┬─────────────────────┬───────────────────────────────────╮
  │ # │        name         │               value               │
  ├───┼─────────────────────┼───────────────────────────────────┤
  │ 0 │ content-type        │ application/pdf                   │
  │ 1 │ content-disposition │ attachment; filename="sample.pdf" │
  │ 2 │ ...                 │ [truncated]                       │
  ╰───┴─────────────────────┴───────────────────────────────────╯
  ```

## Key Changes

### 1. CLI Definition (`src/args.rs`)
- Added the `--inline` boolean flag to `CliArgs`.
- Added mapping to `MiniserveConfig::inline` in `src/config.rs`.

### 2. Single-File Serving (`src/listing.rs`)
- In `file_handler`, if `conf.inline` is enabled, we clone the file's original `ContentDisposition`, change its `disposition` to `DispositionType::Inline`, and apply it back using `set_content_disposition`.

### 3. Directory Serving (`src/main.rs`)
- In `configure_app`, if `conf.inline` is enabled, we configure `actix_files::Files` using `.mime_override(|_| DispositionType::Inline)`.

### 4. Custom Header Conflict Warning (`src/main.rs`)
- Added a warning if any custom `Content-Disposition` header via `--header` are specified, informing automatic default takes precedence.

### 5. Test Suite Refactoring & Integration Tests (`tests/fixtures/mod.rs` & `tests/serve_request.rs`)
- Refactored the `server` fixture in `tests/fixtures/mod.rs` to be a simple, 1-line wrapper around a new, generic `server_with_path` fixture. This allows any test to serve a specific path relative to the temporary directory, keeping the test suite completely DRY and backward-compatible.
  - **Reason:** I searched, and found that there is no tests about single-file serving.
- Added `inline_header_set_directory` in `tests/serve_request.rs` to assert that directory serving correctly sets the `Content-Disposition` header to `inline` when `--inline` is passed.
- Added `inline_header_set_single_file` in `tests/serve_request.rs` to assert that single-file serving correctly sets the `Content-Disposition` header to `inline` when `--inline` is passed.